### PR TITLE
[WFGP-154] When processing hardcoded artifacts for the f-p artifact-l…

### DIFF
--- a/maven-plugin/src/main/java/org/wildfly/galleon/maven/MavenProjectArtifactVersions.java
+++ b/maven-plugin/src/main/java/org/wildfly/galleon/maven/MavenProjectArtifactVersions.java
@@ -82,17 +82,45 @@ class MavenProjectArtifactVersions {
     }
 
     private void put(final String groupId, final String artifactId, final String classifier, final String version, final String type) {
-        put(versions, groupId, artifactId, classifier, version, type);
+        put(versions, groupId, artifactId, classifier, version, type, false);
     }
 
+    /**
+     * Store a key value pair mapping a key to a string value containing a maven groupId:artifactId:version:[classifier:]type.
+     * The key will be one of the following depending on whether the {@code versionedKeys} parameter is {@code true}
+     * and whether {@code classifier} is {@code null} or an empty string:
+     *
+     * <ul>
+     *     <li>groupId:artifactId</li>
+     *     <li>groupId:artifactId::classifier</li>
+     *     <li>groupId:artifactId:version</li>
+     *     <li>groupId:artifactId:version:classifier</li>
+     * </ul>
+     *
+     * @param map the map into which the entry should be stored
+     * @param groupId the maven groupId. Cannot be {@code null}
+     * @param artifactId the maven artifactId. Cannot be {@code null}
+     * @param classifier the maven artifact classifier. May be {@code null}
+     * @param version the maven artifact version. Cannot be {@code null}
+     * @param type the maven artifact type. Cannot be {@code null}
+     * @param versionedKeys {@code true} if the key should include the version; {@code false} if it should be omitted
+     */
     static void put(Map<String, String> map, final String groupId, final String artifactId,
-            final String classifier, final String version, final String type) {
+            final String classifier, final String version, final String type, final boolean versionedKeys) {
         final StringBuilder buf = new StringBuilder(groupId).append(':').
                 append(artifactId);
         final StringBuilder versionClassifier = new StringBuilder(buf);
         versionClassifier.append(':').append(version).append(':');
+
+        if (versionedKeys) {
+            buf.append(":").append(version);
+        }
         if(classifier != null && !classifier.isEmpty()) {
-            buf.append("::").append(classifier);
+            if (!versionedKeys) {
+                // Add the empty spot for the version
+                buf.append(":");
+            }
+            buf.append(":").append(classifier);
             versionClassifier.append(classifier);
         }
         map.put(buf.toString(), versionClassifier.append(':').append(type).toString());

--- a/maven-plugin/src/main/java/org/wildfly/galleon/maven/ModuleXmlVersionResolver.java
+++ b/maven-plugin/src/main/java/org/wildfly/galleon/maven/ModuleXmlVersionResolver.java
@@ -209,9 +209,13 @@ public class ModuleXmlVersionResolver {
                 String artifactCoords = getArtifactCoordinates(artifactName);
                 if (artifactCoords == null) {
                     final ArtifactCoords coords = ArtifactCoords.fromString(artifactName);
+                    // Use the MavenProjectArtifactVersions util method to store this, but
+                    // use the version in the key in order to avoid it being overwritten
+                    // by another entry. A hard coded artifact may well have a different version
+                    // from another artifact in the f-p, as handling that is one reason to hard code
                     MavenProjectArtifactVersions.put(hardcodedArtifacts, coords.getGroupId(),
                             coords.getArtifactId(),  coords.getClassifier(), coords.getVersion(),
-                            coords.getExtension());
+                            coords.getExtension(), true);
                 }
             }
         }


### PR DESCRIPTION
…ist.txt, handle different artifacts with the same mave GA but different version

https://issues.jboss.org/browse/WFGP-154

TBH this is a quick fix. The ArtifactListBuilder is being built using data from a Map<String, String> but the only thing used from the map is the values. This change is just to prevent discarding values because of duplicate keys.

If I have time today I'll do a different PR that changes this to using a Set.