### PR TITLE
[WFGP-154] When processing hardcoded artifacts for the f-p artifact-l…

### DIFF
--- a/maven-plugin/src/main/java/org/wildfly/galleon/maven/AbstractFeaturePackBuildMojo.java
+++ b/maven-plugin/src/main/java/org/wildfly/galleon/maven/AbstractFeaturePackBuildMojo.java
@@ -36,11 +36,10 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
-import java.util.TreeMap;
+import java.util.TreeSet;
 import java.util.stream.Stream;
 import javax.xml.stream.XMLStreamException;
 import nu.xom.ParsingException;
@@ -677,12 +676,12 @@ public abstract class AbstractFeaturePackBuildMojo extends AbstractMojo {
     private void buildArtifactList(ArtifactListBuilder builder) throws MojoExecutionException {
         try {
             final MavenProjectArtifactVersions projectArtifacts = MavenProjectArtifactVersions.getInstance(project);
-            Map<String, String> allArtifacts = new TreeMap<>();
+            Set<String> allArtifacts = new TreeSet<>();
             addHardCodedArtifacts(allArtifacts);
-            allArtifacts.putAll(projectArtifacts.getArtifacts());
+            allArtifacts.addAll(projectArtifacts.getArtifacts().values());
             // Generate the offliner file for dependencies and hardcoded.
-            for (Entry<String, String> entry : allArtifacts.entrySet()) {
-                ArtifactCoords coords = ArtifactCoordsUtil.fromJBossModules(entry.getValue(), null);
+            for (String artifact : allArtifacts) {
+                ArtifactCoords coords = ArtifactCoordsUtil.fromJBossModules(artifact, null);
                 builder.add(coords);
             }
         } catch (ProvisioningException | IOException | ArtifactDescriptorException ex) {
@@ -690,7 +689,7 @@ public abstract class AbstractFeaturePackBuildMojo extends AbstractMojo {
         }
     }
 
-    private void addHardCodedArtifacts(Map<String, String> all) throws IOException {
+    private void addHardCodedArtifacts(Set<String> all) throws IOException {
         Path packages = resourcesDir.resolve(Constants.PACKAGES);
         if (Files.exists(packages)) {
             processPackages(fpDir, all);
@@ -701,7 +700,7 @@ public abstract class AbstractFeaturePackBuildMojo extends AbstractMojo {
         }
     }
 
-    private void processPackages(Path fpDirectory, Map<String, String> all) throws IOException {
+    private void processPackages(Path fpDirectory, Set<String> all) throws IOException {
         Files.walkFileTree(fpDirectory, new SimpleFileVisitor<Path>() {
             @Override
             public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
@@ -714,7 +713,7 @@ public abstract class AbstractFeaturePackBuildMojo extends AbstractMojo {
         });
     }
 
-    private void addHardCodedArtifacts(final Path source, Map<String, String> all) throws IOException {
+    private void addHardCodedArtifacts(final Path source, Set<String> all) throws IOException {
         Files.walkFileTree(source, EnumSet.of(FileVisitOption.FOLLOW_LINKS), Integer.MAX_VALUE,
                 new SimpleFileVisitor<Path>() {
             @Override

--- a/maven-plugin/src/main/java/org/wildfly/galleon/maven/MavenProjectArtifactVersions.java
+++ b/maven-plugin/src/main/java/org/wildfly/galleon/maven/MavenProjectArtifactVersions.java
@@ -82,11 +82,6 @@ class MavenProjectArtifactVersions {
     }
 
     private void put(final String groupId, final String artifactId, final String classifier, final String version, final String type) {
-        put(versions, groupId, artifactId, classifier, version, type);
-    }
-
-    static void put(Map<String, String> map, final String groupId, final String artifactId,
-            final String classifier, final String version, final String type) {
         final StringBuilder buf = new StringBuilder(groupId).append(':').
                 append(artifactId);
         final StringBuilder versionClassifier = new StringBuilder(buf);
@@ -95,7 +90,7 @@ class MavenProjectArtifactVersions {
             buf.append("::").append(classifier);
             versionClassifier.append(classifier);
         }
-        map.put(buf.toString(), versionClassifier.append(':').append(type).toString());
+        versions.put(buf.toString(), versionClassifier.append(':').append(type).toString());
     }
 
     void remove(String groupId, String artifactId) {


### PR DESCRIPTION
…ist.txt, handle different artifacts with the same mave GA but different version

Follow up to #133 that instead of changing the behavior of MavenProjectArtifactVersions to properly handle this offliner artifact-list.txt use case, which I believe is not really what that class is for, instead it is handled directly.

This PR changes a public static method signature:

https://github.com/wildfly/galleon-plugins/compare/master...bstansberry:WFGP-154_2?expand=1#diff-885c8e3547c0c10f94baea33a5a2be8fR184

Since I had to do that I made the method package-protected too, which seems correct.

I also dropped a package-protected method from MavenProjectArtifactVersions as removing this artifact-list.txt use allows that code to be inlined into its only remaining caller.

https://github.com/wildfly/galleon-plugins/compare/master...bstansberry:WFGP-154_2?expand=1#diff-8393c3011c78d0be5d136b0e8753e6deL88

The #133 approach is a smaller change but this seems cleaner overall.