### PR TITLE
Fix for WFGP-167, GA producer in build descriptor should not require …

### DIFF
--- a/maven-plugin/src/main/java/org/wildfly/galleon/maven/WfFeaturePackBuildMojo.java
+++ b/maven-plugin/src/main/java/org/wildfly/galleon/maven/WfFeaturePackBuildMojo.java
@@ -170,13 +170,17 @@ public class WfFeaturePackBuildMojo extends AbstractFeaturePackBuildMojo {
         }
 
         FeaturePackLocation fpl = buildConfig.getProducer();
-        String channel = fpl.getChannelName();
-        if(channel == null || channel.isEmpty()) {
-            final String v = project.getVersion();
-            final int i = v.indexOf('.');
-            channel = i < 0 ? v : v.substring(0, i);
+        if (!fpl.hasUniverse() && !fpl.hasBuild()) {
+            fpl = FeaturePackLocation.fromString(fpl.toString() + ":" + project.getVersion());
+        } else {
+            String channel = fpl.getChannelName();
+            if (channel == null || channel.isEmpty()) {
+                final String v = project.getVersion();
+                final int i = v.indexOf('.');
+                channel = i < 0 ? v : v.substring(0, i);
+            }
+            fpl = new FeaturePackLocation(fpl.getUniverse(), fpl.getProducerName(), channel, null, project.getVersion());
         }
-        fpl = new FeaturePackLocation(fpl.getUniverse(), fpl.getProducerName(), channel, null, project.getVersion());
 
         // feature-pack builder
         final FeaturePackDescription.Builder fpBuilder = FeaturePackDescription.builder(FeaturePackSpec.builder(fpl.getFPID()));


### PR DESCRIPTION
…to end with ':' character