### PR TITLE
WFGP-179, WFGP-183 and WFGP-186

### DIFF
--- a/galleon-plugins/src/main/java/org/wildfly/galleon/plugin/WfConstants.java
+++ b/galleon-plugins/src/main/java/org/wildfly/galleon/plugin/WfConstants.java
@@ -63,6 +63,7 @@ public interface WfConstants {
     String VALUE = "value";
     String WILDFLY = "wildfly";
     String WILDFLY_TASKS_PROPS = "wildfly-tasks.properties";
+    String WILDFLY_JAKARTA_TRANSFORM_EXCLUDES = "wildfly-jakarta-transform-excludes.txt";
     String WILDFLY_TASKS_XML = "wildfly-tasks.xml";
 
     // Feature annotation names and elements

--- a/galleon-plugins/src/main/java/org/wildfly/galleon/plugin/WfInstallPlugin.java
+++ b/galleon-plugins/src/main/java/org/wildfly/galleon/plugin/WfInstallPlugin.java
@@ -132,6 +132,9 @@ public class WfInstallPlugin extends ProvisioningPluginWithOptions implements In
     private static final ProvisioningOption OPTION_MVN_PROVISIONING_REPO = ProvisioningOption.builder("jboss-maven-provisioning-repo")
             .setPersistent(false)
             .build();
+    private static final ProvisioningOption OPTION_JAKARTA_TRANSFORM_ARTIFACTS_VERBOSE = ProvisioningOption.builder("jboss-jakarta-transform-artifacts-verbose")
+            .setBooleanValueSet()
+            .build();
     private ProvisioningRuntime runtime;
     private MessageWriter log;
 
@@ -173,7 +176,8 @@ public class WfInstallPlugin extends ProvisioningPluginWithOptions implements In
     @Override
     protected List<ProvisioningOption> initPluginOptions() {
         return Arrays.asList(OPTION_MVN_DIST, OPTION_DUMP_CONFIG_SCRIPTS,
-                OPTION_FORK_EMBEDDED, OPTION_MVN_REPO, OPTION_JAKARTA_TRANSFORM_ARTIFACTS, OPTION_MVN_PROVISIONING_REPO);
+                OPTION_FORK_EMBEDDED, OPTION_MVN_REPO, OPTION_JAKARTA_TRANSFORM_ARTIFACTS,
+                OPTION_MVN_PROVISIONING_REPO, OPTION_JAKARTA_TRANSFORM_ARTIFACTS_VERBOSE);
     }
 
     public ProvisioningRuntime getRuntime() {
@@ -201,6 +205,14 @@ public class WfInstallPlugin extends ProvisioningPluginWithOptions implements In
             return true;
         }
         final String value = runtime.getOptionValue(OPTION_JAKARTA_TRANSFORM_ARTIFACTS);
+        return value == null ? true : Boolean.parseBoolean(value);
+    }
+
+    private boolean isVerboseTransformation() throws ProvisioningException {
+        if (!runtime.isOptionSet(OPTION_JAKARTA_TRANSFORM_ARTIFACTS_VERBOSE)) {
+            return false;
+        }
+        final String value = runtime.getOptionValue(OPTION_JAKARTA_TRANSFORM_ARTIFACTS_VERBOSE);
         return value == null ? true : Boolean.parseBoolean(value);
     }
 
@@ -307,7 +319,7 @@ public class WfInstallPlugin extends ProvisioningPluginWithOptions implements In
             // initialize jakarta transformation properties
 
             jakartaTransform = isTransformationEnabled() && Boolean.valueOf(mergedTaskProps.getOrDefault(JakartaTransformer.TRANSFORM_ARTIFACTS, "false"));
-            jakartaTransformVerbose = Boolean.valueOf(mergedTaskProps.getOrDefault(JakartaTransformer.TRANSFORM_VERBOSE, "false"));
+            jakartaTransformVerbose = isVerboseTransformation();
             final String jakartaConfigsDir = mergedTaskProps.get(JakartaTransformer.TRANSFORM_CONFIGS_DIR);
             if (jakartaConfigsDir != null) {
                 jakartaTransformConfigsDir = Paths.get(jakartaConfigsDir);

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
     <!-- Checkstyle configuration -->
     <linkXRef>false</linkXRef>
     <version.org.wildfly.checkstyle-config>1.0.8.Final</version.org.wildfly.checkstyle-config>
-    <version.org.wildfly.extras.batavia>1.0.0.Final</version.org.wildfly.extras.batavia>
+    <version.org.wildfly.extras.batavia>1.0.1.Final</version.org.wildfly.extras.batavia>
     <version.org.jboss.staxmapper>1.1.0.Final</version.org.jboss.staxmapper>
 
     <!-- license-maven-plugin configuration -->


### PR DESCRIPTION
Issues:
* https://issues.redhat.com/projects/WFGP/issues/WFGP-179
* https://issues.redhat.com/projects/WFGP/issues/WFGP-183
* https://issues.redhat.com/projects/WFGP/issues/WFGP-186

* Package a file inside f-p containing the list of artifacts that don't require transformation during provisioning.
* Ability to disable transformation by relying on a "provisioning local maven repo".
* Slim server provisioning, proper handling of local maven cache.
* Ability to enable traces in transformer Main entry point and during provisioning.
* Upgrade to batavia 1.0.1

@bstansberry , I am adding some documentation on what happens in the various provisioning scenarii.

Fat server with transformation

* During module transformation, populate transformationMavenRepo for example configs to avoid re-transform.
* When generating main config, do not set jboss.repo.local, we use the fat server.
* When generating example configs (re-do of provisioning of a slim-server), set jboss.repo.local to reference transformationMavenRepo

Slim server with transformation and jboss-maven-repo

* During module transformation, populate jboss-maven-repo
* When generating main config, jboss.repo.local to reference the jboss-maven-repo
* When generating example configs (re-do of provisioning of a slim-server), set jboss.repo.local to reference  jboss-maven-repo

Fat server with a provisioning-repo, no transformation (repo already contains transformed artifacts).

* During module handling, copy modules from provisioning-repo to wildfly server.
* When generating main config, do not set jboss.repo.local, we use the fat server
* When generating example configs (re-do of provisioning of a slim-server), set jboss.repo.local to reference provisioning-repo

Slim server with a provisioning-repo, no transformation (repo already contains transformed artifacts).

* During module handling, do nothing.
* When generating main config,  jboss.repo.local to reference the provisioning-repo
* When generating example configs (re-do of provisioning of a slim-server), set jboss.repo.local to reference provisioning-repo

Slim server with a provisioning-repo and jboss-maven-repo, no transformation (repo already contains transformed artifacts).

* During module handling, copy artifacts from provisioning-repo to jboss-maven-repo
* When generating main config,  jboss.repo.local to reference the jboss-maven-repo
* When generating example configs (re-do of provisioning of a slim-server), set jboss.repo.local to reference provisioning-repo
