### PR TITLE
Decoupling Batavia dependencies from Galleon Plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -329,12 +329,6 @@
       </dependency>
 
       <dependency>
-        <groupId>org.wildfly.extras.batavia</groupId>
-        <artifactId>transformer-impl-eclipse</artifactId>
-        <version>${version.org.wildfly.extras.batavia}</version>
-      </dependency>
-
-      <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
         <version>${version.junit}</version>

--- a/transformer/pom.xml
+++ b/transformer/pom.xml
@@ -36,11 +36,7 @@
     <dependency>
       <groupId>org.wildfly.extras.batavia</groupId>
       <artifactId>transformer-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.wildfly.extras.batavia</groupId>
-      <artifactId>transformer-impl-eclipse</artifactId>
-      <scope>runtime</scope>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
This PR @bstansberry @jfdenise is a second step of Batavia decoupling from Galleon Plugins.
The following PR https://github.com/bstansberry/wildfly/pull/56 must be applied first to WildFly ee-9 topic branch.
