### PR TITLE
Fix for WFGP-188, Rename jakarta transformed artifacts

### DIFF
--- a/maven-plugin/src/main/java/org/wildfly/galleon/maven/AbstractFeaturePackBuildMojo.java
+++ b/maven-plugin/src/main/java/org/wildfly/galleon/maven/AbstractFeaturePackBuildMojo.java
@@ -149,7 +149,7 @@ public abstract class AbstractFeaturePackBuildMojo extends AbstractMojo {
      * from task-properties-file parameter, in case it's also set.<br/>
      */
     @Parameter(alias = "task-properties", required = false)
-    private Map<String, String> taskProps = Collections.emptyMap();
+    protected Map<String, String> taskProps = Collections.emptyMap();
 
     @Component
     protected RepositorySystem repoSystem;


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFGP-188
@bstansberry that is the renaming feature.
Add suffix to FP configuration.
Use suffix for transformed artifact. 
Fat server: Update artifact name and module.xml.
Thin server: Update module.xml artifacts GAV, locate renamed artifact in a version directory containing the suffix.
Feature-spec generation is done based on non re-named artifacts (this is an internal provisioning). The generated maven repository (that can be used as a cache to provision servers without the need to transform artifacts in later steps) contains the  renamed artifact.
