### PR TITLE
Fix for WFGP-197, Ability to scope an artifact upgrade inside a feature-pack

### DIFF
--- a/galleon-plugins/src/test/java/org/wildfly/galleon/plugin/UtilsTestCase.java
+++ b/galleon-plugins/src/test/java/org/wildfly/galleon/plugin/UtilsTestCase.java
@@ -29,7 +29,7 @@ public class UtilsTestCase {
     public void testOverriddenArtifacts() throws Exception {
         {
             String str = "grp:art:vers:class:jar";
-            Map<String, String> map = Utils.toArtifactsMap(str);
+            Map<String, String> map = getGlobalScope(str);
             Assert.assertEquals(1, map.size());
             String key = "grp:art::class";
             String value = map.get(key);
@@ -38,7 +38,7 @@ public class UtilsTestCase {
 
         {
             String str = "grp:art:vers::jar";
-            Map<String, String> map = Utils.toArtifactsMap(str);
+            Map<String, String> map = getGlobalScope(str);
             Assert.assertEquals(1, map.size());
             String key = "grp:art";
             String value = map.get(key);
@@ -55,7 +55,7 @@ public class UtilsTestCase {
                 str1 + "|" + str2 + "|" + str3,
                 "  " + str1 + " | " + str2 + "   " + " | " + str3};
             for (String str : cases) {
-                Map<String, String> map = Utils.toArtifactsMap(str);
+                Map<String, String> map = getGlobalScope(str);
                 Assert.assertEquals(3, map.size());
                 String key1 = "grp:art";
                 String value1 = map.get(key1);
@@ -84,12 +84,63 @@ public class UtilsTestCase {
                 "a:b:c:d:e| :b:c:d:  "};
             for (String str : invalids) {
                 try {
-                    Map<String, String> map = Utils.toArtifactsMap(str);
+                    Map<String, String> map = getGlobalScope(str);
                     throw new Exception("Should have failed");
                 } catch (IllegalArgumentException ex) {
                     // XXX OK expected
                 }
             }
         }
+    }
+
+    @Test
+    public void testOverriddenArtifactsProducers() throws Exception {
+        {
+            String artifacts = "grp:art:vers:class:jar";
+            String str = "@foo=" + artifacts;
+            Map<String, String> map = getProducerScope(str, "foo");
+            Assert.assertEquals(1, map.size());
+            String key = "grp:art::class";
+            String value = map.get(key);
+            Assert.assertEquals(artifacts, value);
+        }
+
+        {
+            String global = "grp:art:vers::jar";
+            String producer1 = "foo";
+            String producer1Artifact = "grp:art:vers2::jar";
+            String producer2 = "bar";
+            String producer2Artifact1 = "grp2:art2:vers::jar";
+            String producer2Artifact2 = "grp2:art3:vers::jar";
+            String str = global +"@"+producer1+"="+producer1Artifact +"@"+producer2+"="+producer2Artifact1 + "|"+producer2Artifact2 ;
+            Map<String, String> map = getGlobalScope(str);
+            Assert.assertEquals(1, map.size());
+            String key = "grp:art";
+            String value = map.get(key);
+            Assert.assertEquals(global, value);
+
+            Map<String, String> map2 = getProducerScope(str, producer1);
+            Assert.assertEquals(1, map2.size());
+            String key2 = "grp:art";
+            String value2 = map2.get(key2);
+            Assert.assertEquals(producer1Artifact, value2);
+
+            Map<String, String> map3 = getProducerScope(str, producer2);
+            Assert.assertEquals(2, map3.size());
+            String key3 = "grp2:art2";
+            String value3 = map3.get(key3);
+            Assert.assertEquals(producer2Artifact1, value3);
+            String key4 = "grp2:art3";
+            String value4 = map3.get(key4);
+            Assert.assertEquals(producer2Artifact2, value4);
+        }
+    }
+
+    private static Map<String, String> getGlobalScope(String str) {
+        return Utils.toArtifactsMap(str).get(WfInstallPlugin.GLOBAL_ARTIFACTS_KEY);
+    }
+
+    private static Map<String, String> getProducerScope(String str, String producer) {
+        return Utils.toArtifactsMap(str).get(producer);
     }
 }


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFGP-197
This change is backward compatible,the list of artifacts in the option value was implicitly bound to the global scope. In addition to the "global scope", a "producer scope" can be provided to narrow the set of artifacts to upgrade.
