### PR TITLE
Support expression in versions.

### DIFF
--- a/galleon-plugins/pom.xml
+++ b/galleon-plugins/pom.xml
@@ -137,6 +137,24 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>default-test</id>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <phase>test</phase>
+            <configuration>
+              <environmentVariables>
+                <WFGP_TEST_VERSION>7777</WFGP_TEST_VERSION>
+              </environmentVariables>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 

--- a/maven-plugin/src/main/java/org/wildfly/galleon/maven/AbstractFeaturePackBuildMojo.java
+++ b/maven-plugin/src/main/java/org/wildfly/galleon/maven/AbstractFeaturePackBuildMojo.java
@@ -263,9 +263,14 @@ public abstract class AbstractFeaturePackBuildMojo extends AbstractMojo {
         for (ArtifactCoords.Gav gav : buildConfig.getDependencies().keySet()) {
             getArtifactVersions().remove(gav.getGroupId(), gav.getArtifactId());
         }
+        // Copy resources from src.
         try {
+            Path srcArtifacts = resourcesDir.resolve(Constants.RESOURCES);
+            if (Files.exists(srcArtifacts)) {
+               IoUtils.copy(srcArtifacts, fpResourcesDir);
+            }
             getArtifactVersions().store(resourcesWildFly.resolve(WfConstants.ARTIFACT_VERSIONS_PROPS));
-        } catch (IOException e) {
+        } catch (ProvisioningException | IOException e) {
             throw new MojoExecutionException("Failed to store artifact versions", e);
         }
         // Build a maven artifact resolver that looks into the local maven repo, not in the project


### PR DESCRIPTION
* Evolve the user feature-pack maven plugin to copy resources.
* Store the artifacts versions only if key doesn't exist in versions file.
* Evolve galleon plugin to resolve version "expression".

