### PR TITLE
Fix for WFGP-195, Can't provision WildFly using JDK 16.

### DIFF
--- a/galleon-plugins/pom.xml
+++ b/galleon-plugins/pom.xml
@@ -63,14 +63,10 @@
     </dependency>
 
     <dependency>
-      <groupId>com.io7m.xom</groupId>
+      <groupId>xom</groupId>
       <artifactId>xom</artifactId>
       <scope>compile</scope>
       <exclusions>
-        <exclusion>
-          <groupId>xml-apis</groupId>
-          <artifactId>xml-apis</artifactId>
-        </exclusion>
         <exclusion>
           <groupId>xalan</groupId>
           <artifactId>xalan</artifactId>
@@ -130,7 +126,6 @@
                   <exclude>org.wildfly.security:wildfly-elytron</exclude>
                   <exclude>xalan:xalan</exclude>
                   <exclude>xerces:xercesImpl</exclude>
-                  <exclude>xml-apis:xml-apis</exclude>
                 </excludes>
               </artifactSet>
             </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
     <version.org.wildfly.maven.plugins>2.0.0.Final</version.org.wildfly.maven.plugins>
     <version.org.jboss.logging>3.3.1.Final</version.org.jboss.logging>
     <version.org.jboss.logmanager>2.0.6.Final</version.org.jboss.logmanager>
-    <version.com.io7m.xom>1.2.10</version.com.io7m.xom>
+    <version.xom>1.3.7</version.xom>
     <!-- sfl4j is brought in by eclipse aether and version needs to be overridden. Currently only used in tool module -->
     <version.org.slf4j>1.7.21</version.org.slf4j>
     <version.org.jboss.logging.slf4j-jboss-logging>1.1.0.Final</version.org.jboss.logging.slf4j-jboss-logging>
@@ -260,9 +260,9 @@
       </dependency>
 
       <dependency>
-        <groupId>com.io7m.xom</groupId>
+        <groupId>xom</groupId>
         <artifactId>xom</artifactId>
-        <version>${version.com.io7m.xom}</version>
+        <version>${version.xom}</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.aether</groupId>


### PR DESCRIPTION
New version of XOM doesn't access to JDK internal classes.
* Upgraded XOM dependency (groupid changed).
* Removed xml-apis that is no more a dependency.