### PR TITLE
[WFGP-202] Upgrade Batavia to 1.0.8.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
     <!-- Checkstyle configuration -->
     <linkXRef>false</linkXRef>
     <version.org.wildfly.checkstyle-config>1.0.8.Final</version.org.wildfly.checkstyle-config>
-    <version.org.wildfly.extras.batavia>1.0.6.Final</version.org.wildfly.extras.batavia>
+    <version.org.wildfly.extras.batavia>1.0.8.Final</version.org.wildfly.extras.batavia>
     <version.org.jboss.staxmapper>1.1.0.Final</version.org.jboss.staxmapper>
 
     <!-- license-maven-plugin configuration -->


### PR DESCRIPTION
Brings in fixes:
 * [BATAVIA-101] Transform the legacy JAXB NS to the EE9

https://issues.redhat.com/browse/WFGP-202
Upstream: #199 