### PR TITLE
[WFGP-199]: Useless error: org.jboss.galleon.ProvisioningException:Packages dependencies don't match.

### DIFF
--- a/feature-spec-gen/src/main/java/org/wildfly/galleon/plugin/featurespec/generator/FeatureSpecNode.java
+++ b/feature-spec-gen/src/main/java/org/wildfly/galleon/plugin/featurespec/generator/FeatureSpecNode.java
@@ -161,16 +161,20 @@ class FeatureSpecNode {
             }
         }
         final List<ModelNode> packagesDescr = domainDescr.hasDefined("packages") ? domainDescr.get("packages").asList() : Collections.emptyList();
-        if(packagesDescr.size() != standalonePackages.size()) {
-            if(failIfDifferent) {
-                throw new ProvisioningException("Packages dependencies don't match");
+        Set<String> domainPackages = new HashSet<>(packagesDescr.size());
+        for (ModelNode packageDep : packagesDescr) {
+            domainPackages.add(packageDep.require("package").asString());
+        }
+        if (domainPackages.size() != standalonePackages.size()) {
+            if (failIfDifferent) {
+                throw new ProvisioningException("Domain packages dependencies [" + String.join(",", domainPackages) + "] don't match standalone packages dependencies [" + String.join(",", standalonePackages) + "]");
             }
             return false;
         }
-        for (ModelNode packageDep : packagesDescr) {
-            if(!standalonePackages.contains(packageDep.require("package").asString())) {
-                if(failIfDifferent) {
-                    throw new ProvisioningException("Domain model feature requires package " + packageDep.require("package").asString() + " unlike the standalone one");
+        for (String packageDep : domainPackages) {
+            if (!standalonePackages.contains(packageDep)) {
+                if (failIfDifferent) {
+                    throw new ProvisioningException("Domain model feature requires package " + packageDep + " unlike the standalone one");
                 }
                 return false;
             }


### PR DESCRIPTION
 * Fixing this by transforming the domain packages description as a Set instead of a List to compare it properly with the Set from
standalone.

Jira: https://issues.redhat.com/browse/WFGP-199