### PR TITLE
Fix for WFGP-205, Dependency order in wildfly-feature-pack-build is not preserved

### DIFF
--- a/maven-plugin/src/main/java/org/wildfly/galleon/maven/WildFlyFeaturePackBuild.java
+++ b/maven-plugin/src/main/java/org/wildfly/galleon/maven/WildFlyFeaturePackBuild.java
@@ -67,7 +67,7 @@ public class WildFlyFeaturePackBuild {
         }
 
         public Builder addDependency(Gav gav, FeaturePackDependencySpec dependency) {
-            dependencies = CollectionUtils.put(dependencies, gav, dependency);
+            dependencies = CollectionUtils.putLinked(dependencies, gav, dependency);
             return this;
         }
 


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFGP-205