### PR TITLE
[WFGP-207] Do not add a "security-realm" reference in the initial config.

### DIFF
--- a/maven-plugin/src/main/java/org/wildfly/galleon/maven/FeatureSpecGeneratorInvoker.java
+++ b/maven-plugin/src/main/java/org/wildfly/galleon/maven/FeatureSpecGeneratorInvoker.java
@@ -407,7 +407,7 @@ public class FeatureSpecGeneratorInvoker {
             lines.add("</extensions>");
             lines.add("<management>");
             lines.add("<management-interfaces>");
-            lines.add("<http-interface security-realm=\"ManagementRealm\">");
+            lines.add("<http-interface>");
             lines.add("<http-upgrade enabled=\"true\"/>");
             lines.add("<socket interface=\"management\" port=\"${jboss.management.http.port:9990}\"/>");
             lines.add("</http-interface>");


### PR DESCRIPTION


https://issues.redhat.com/browse/WFGP-207