### PR TITLE
Fix for WFGP-208, Generation of wildfly-jakarta-transform-excludes.txt is bound to feature-spec generation

### DIFF
--- a/maven-plugin/src/main/java/org/wildfly/galleon/maven/JakartaTransformation.java
+++ b/maven-plugin/src/main/java/org/wildfly/galleon/maven/JakartaTransformation.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2016-2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.galleon.maven;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.jboss.galleon.util.IoUtils;
+import org.wildfly.galleon.plugin.ArtifactCoords;
+import org.wildfly.galleon.plugin.WfConstants;
+import org.wildfly.galleon.plugin.WfInstallPlugin;
+import org.wildfly.galleon.plugin.transformer.JakartaTransformer;
+import org.wildfly.galleon.plugin.transformer.TransformedArtifact;
+
+/**
+ *
+ * @author jdenise
+ */
+public class JakartaTransformation {
+
+    private final boolean jakartaTransform;
+    private final boolean jakartaTransformVerbose;
+    private final Path jakartaTransformConfigsDir;
+    private final Path jakartaTransformMavenRepo;
+    private final Set<String> transformExcluded = new TreeSet<>();
+    private final String jakartaTransformSuffix;
+    private final Pattern excludedArtifactPattern;
+    private final Set<Artifact> transformed = new HashSet<>();
+    private final JakartaTransformer.LogHandler logHandler;
+    private final Log log;
+
+    JakartaTransformation(Log log, boolean jakartaTransform, boolean jakartaTransformVerbose,
+            File jakartaTransformConfigsDir, File jakartaTransformRepo, String jakartaTransformSuffix,
+            List<String> jakartaTransformExcludedArtifacts) {
+        this.log = log;
+        this.jakartaTransform = jakartaTransform;
+        this.jakartaTransformVerbose = jakartaTransformVerbose;
+        this.jakartaTransformConfigsDir = jakartaTransformConfigsDir == null ? null : jakartaTransformConfigsDir.toPath();
+        this.jakartaTransformMavenRepo = jakartaTransformRepo.toPath();
+        this.jakartaTransformSuffix = jakartaTransformSuffix;
+        this.excludedArtifactPattern = (jakartaTransformExcludedArtifacts == null
+                || jakartaTransformExcludedArtifacts.isEmpty()) ? null
+                : Pattern.compile(toExcludedPattern(jakartaTransformExcludedArtifacts));
+        JakartaTransformer.LogHandler logHandler = null;
+        if (jakartaTransform) {
+            logHandler = new JakartaTransformer.LogHandler() {
+                @Override
+                public void print(String format, Object... args) {
+                    log.info(String.format(format, args));
+                }
+            };
+            IoUtils.recursiveDelete(jakartaTransformMavenRepo);
+        }
+        this.logHandler = logHandler;
+    }
+
+    private boolean isAlreadyTransformed(Artifact a) {
+        return transformed.contains(a);
+    }
+
+    boolean isJakartaTransformEnabled() {
+        return jakartaTransform;
+    }
+
+    boolean transform(Artifact artifact) throws MojoExecutionException, IOException {
+        if (isAlreadyTransformed(artifact)) {
+            return false;
+        }
+        String grpid = artifact.getGroupId().replaceAll("\\.", Matcher.quoteReplacement(File.separator));
+        Path grpidPath = getJakartaTransformMavenRepo().resolve(grpid);
+        Path artifactidPath = grpidPath.resolve(artifact.getArtifactId());
+        Path versionPath = artifactidPath.resolve(artifact.getVersion());
+        Files.createDirectories(versionPath);
+        boolean isTransformed = transform(artifact, versionPath);
+        if (isTransformed && jakartaTransformSuffix != null) {
+            // Copy a renamed version that will be used for future provisioning.
+            Path transformedVersionPath = artifactidPath.resolve(artifact.getVersion() + jakartaTransformSuffix);
+            Files.createDirectories(transformedVersionPath);
+            String fileName = WfInstallPlugin.getTransformedArtifactFileName(artifact.getVersion(),
+                    artifact.getFile().toPath().getFileName().toString(), jakartaTransformSuffix);
+            Files.copy(versionPath.resolve(artifact.getFile().toPath().getFileName()),
+                    transformedVersionPath.resolve(fileName), StandardCopyOption.REPLACE_EXISTING);
+        }
+        return isTransformed;
+    }
+
+    private boolean transform(Artifact artifact, Path target) throws MojoExecutionException, IOException {
+        if (isAlreadyTransformed(artifact)) {
+            return false;
+        }
+        boolean isTransformed;
+        if (isExcludedFromTransformation(artifact)) {
+            transformExcluded.add(ArtifactCoords.newGav(artifact.getGroupId(),
+                    artifact.getArtifactId(), artifact.getVersion()).toString());
+            isTransformed = false;
+        } else {
+            TransformedArtifact a = JakartaTransformer.transform(jakartaTransformConfigsDir,
+                    artifact.getFile().toPath(), target, jakartaTransformVerbose, logHandler);
+            isTransformed = a.isTransformed();
+            if (!a.isTransformed()) {
+                transformExcluded.add(ArtifactCoords.newGav(artifact.getGroupId(),
+                        artifact.getArtifactId(), artifact.getVersion()).toString());
+            }
+        }
+        transformed.add(artifact);
+        return isTransformed;
+    }
+
+    Path getJakartaTransformMavenRepo() {
+        return jakartaTransformMavenRepo;
+    }
+
+    void writeExcludedArtifactsFile(Path wildflyResourcesDir) throws MojoExecutionException {
+        if (!transformExcluded.isEmpty()) {
+            try {
+                Path excludedFilePath = wildflyResourcesDir.resolve(WfConstants.WILDFLY_JAKARTA_TRANSFORM_EXCLUDES);
+                Util.mkdirs(wildflyResourcesDir);
+                StringBuilder builder = new StringBuilder();
+                for (String s : transformExcluded) {
+                    builder.append(s).append(System.lineSeparator());
+                }
+                Files.write(excludedFilePath, builder.toString().getBytes(StandardCharsets.UTF_8), StandardOpenOption.CREATE);
+            } catch (IOException ex) {
+                throw new MojoExecutionException(ex.getMessage(), ex);
+            }
+        }
+    }
+
+    private boolean isExcludedFromTransformation(Artifact artifact) throws MojoExecutionException {
+        if (excludedArtifactPattern != null) {
+            try {
+                Matcher matchArtifact = excludedArtifactPattern.matcher(artifact.getGroupId() + ":" + artifact.getArtifactId());
+                if (matchArtifact.find()) {
+                    log.info("EE9: excluded " + artifact.getGroupId() + ":" + artifact.getArtifactId());
+                    return true;
+                }
+            } catch (PatternSyntaxException e) {
+                throw new MojoExecutionException("Invalid exclusion pattern: " + e.getMessage(), e);
+            }
+        }
+        return false;
+    }
+
+    private static String toExcludedPattern(List<String> patterns) {
+        StringBuilder builder = new StringBuilder();
+        for (int i = 0; i < patterns.size(); i++) {
+            builder.append(patterns.get(i));
+            if (i < patterns.size() - 1) {
+                builder.append("|");
+            }
+        }
+        return builder.toString();
+    }
+}

--- a/maven-plugin/src/main/java/org/wildfly/galleon/maven/UserFeaturePackBuildMojo.java
+++ b/maven-plugin/src/main/java/org/wildfly/galleon/maven/UserFeaturePackBuildMojo.java
@@ -146,6 +146,8 @@ public class UserFeaturePackBuildMojo extends AbstractFeaturePackBuildMojo {
         if (Files.exists(srcModulesDir)) {
             addModulePackages(srcModulesDir, fpBuilder, resources);
         }
+        // Jakarta Transformation occurs to only generate a list of excluded artifacts
+        transformOnlyArtifactDependencies(buildConfig);
 
         buildFeaturePack(fpBuilder, buildConfig);
     }

--- a/maven-plugin/src/main/java/org/wildfly/galleon/maven/WfFeaturePackBuildMojo.java
+++ b/maven-plugin/src/main/java/org/wildfly/galleon/maven/WfFeaturePackBuildMojo.java
@@ -29,7 +29,6 @@ import java.nio.file.SimpleFileVisitor;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -141,47 +140,6 @@ public class WfFeaturePackBuildMojo extends AbstractFeaturePackBuildMojo {
     @Parameter(alias = "feature-specs-output", defaultValue = "${project.build.directory}/resources/features", required = true)
     protected File featureSpecsOutput;
 
-    /**
-     * Whether to transform artifacts from javax.* to jakarta.* before generating feature specs.
-     */
-    @Parameter(alias = "jakarta-transform", required = false)
-    protected boolean jakartaTransform;
-
-    /**
-     * Directory where external user provided transformation configs are located (turns of default transformation rules).
-     */
-    @Parameter(alias = "jakarta-transform-configs-dir", required = false)
-    protected File jakartaTransformConfigsDir;
-
-    /**
-     * If jakarta-transform is true, whether to produce verbose log output of the transformation work.
-     */
-    @Parameter(alias = "jakarta-transform-verbose", required = false)
-    protected boolean jakartaTransformVerbose;
-
-    /**
-     * The directory where a generated local maven repo containing Jakarta-transformed artifacts are stored.
-     */
-    @Parameter(alias = "jakarta-transform-maven-repo", defaultValue = "${project.build.directory}/jakarta-transform-maven-repo", required = true)
-    protected File jakartaTransformRepo;
-
-    /**
-     * A list of regular expression filters to exclude a list of
-     * GroupId:ArtifactId from jakarta transformation. For example, to exclude
-     * wildfly-ee and smallrye-config artifacts:
-     * <br/>
-     * <pre>
-     * {@code
-     * <jakarta-transform-excluded-artifacts>
-     *   <exclude>org.wildfly:wildfly-ee\z</exclude>
-     *   <exclude>io.smallrye.config:smallrye-config\z</exclude>
-     * </jakarta-transform-excluded-artifacts>
-     * }
-     * </pre>
-     */
-    @Parameter(alias = "jakarta-transform-excluded-artifacts", required = false)
-    protected List<String> jakartaTransformExcludedArtifacts;
-
     private WildFlyFeaturePackBuild buildConfig;
     private Map<String, PackageSpec.Builder> extendedPackages = Collections.emptyMap();
 
@@ -209,6 +167,9 @@ public class WfFeaturePackBuildMojo extends AbstractFeaturePackBuildMojo {
 
         if(buildConfig.hasStandaloneExtensions() || buildConfig.hasDomainExtensions() || buildConfig.hasHostExtensions()) {
             new FeatureSpecGeneratorInvoker(this).execute();
+        } else {
+            // Jakarta Transformation would occur in order to  generate a list of excluded artifacts
+            transformOnlyArtifactDependencies(buildConfig);
         }
 
         FeaturePackLocation fpl = buildConfig.getProducer();


### PR DESCRIPTION
* Transformation can occur for FP dependencies when no extension is present.
* Transformation also applies to UserFeaturePackBuildMojo
* Generation of excluded artifacts occurs in all cases (if transformation is enabled).
