### PR TITLE
Fix for WFGP-212, Finalize CLI script execution requires launcher API to be in classpath

### DIFF
--- a/config-gen/src/main/java/org/wildfly/galleon/plugin/config/generator/CliScriptRunner.java
+++ b/config-gen/src/main/java/org/wildfly/galleon/plugin/config/generator/CliScriptRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 Red Hat, Inc. and/or its affiliates
+ * Copyright 2016-2021 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.wildfly.galleon.plugin.server;
+package org.wildfly.galleon.plugin.config.generator;
 
 import java.io.BufferedReader;
 import java.io.BufferedWriter;


### PR DESCRIPTION
* org.wildfly.core:wildfly-launcher classes are not in the shaded plugins jar.
* Moved CLi script invoker in config-gen project.
* Setting classloader prior to call CLI script
