### PR TITLE
[WFGP-230] Using resolveAll to resolve jboss modules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
     <version.org.codehaus.mojo.xml-maven-plugin>1.0.1</version.org.codehaus.mojo.xml-maven-plugin>
     <version.org.codehaus.plexus.plexus-utils>3.1.0</version.org.codehaus.plexus.plexus-utils>
     <version.org.eclipse.aether>1.1.0</version.org.eclipse.aether>
-    <version.org.jboss.galleon>5.0.1.Final</version.org.jboss.galleon>
+    <version.org.jboss.galleon>5.0.2.Final</version.org.jboss.galleon>
     <version.org.jboss.dmr>1.5.0.Final</version.org.jboss.dmr>
     <version.org.jboss.jandex>2.0.3.Final</version.org.jboss.jandex>
     <version.org.wildfly.channel>1.0.0.Alpha16</version.org.wildfly.channel>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFGP-230

If 'bulk-resolve-artifacts' option is specified, module templates are scanned before being processing to build a list of required artifacts.
All the required artifacts are then resolved in a single Maven operation rather then individual requests.

Note: depends on Galleon API change https://github.com/wildfly/galleon/pull/305
Note 2: related channels change: https://github.com/wildfly-extras/wildfly-channel/pull/75