### PR TITLE
[WFGP-232] Add phase attribute to line-ending filter

### DIFF
--- a/galleon-plugins/src/main/java/org/wildfly/galleon/plugin/WfInstallPlugin.java
+++ b/galleon-plugins/src/main/java/org/wildfly/galleon/plugin/WfInstallPlugin.java
@@ -17,12 +17,10 @@
 package org.wildfly.galleon.plugin;
 
 import java.io.BufferedReader;
-import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.io.UncheckedIOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -39,7 +37,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.StandardCopyOption;
-import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -54,6 +51,7 @@ import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.Set;
 import java.util.regex.Matcher;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -93,7 +91,7 @@ import org.wildfly.galleon.plugin.config.CopyArtifact;
 import org.wildfly.galleon.plugin.config.CopyPath;
 import org.wildfly.galleon.plugin.config.DeletePath;
 import org.wildfly.galleon.plugin.config.ExampleFpConfigs;
-import org.wildfly.galleon.plugin.config.FileFilter;
+import org.wildfly.galleon.plugin.config.LineEndingsTask;
 import org.wildfly.galleon.plugin.config.XslTransform;
 import org.wildfly.galleon.plugin.transformer.JakartaTransformer;
 
@@ -856,7 +854,17 @@ public class WfInstallPlugin extends ProvisioningPluginWithOptions implements In
                     mkdirs(pkgTasks, this.runtime.getStagedDir());
                 }
 
-                changeLineEndings(pkgTasks, this.runtime.getStagedDir());
+                final List<WildFlyPackageTask> finalizingLineEndingTasks = pkgTasks.getLineEndings().stream().filter(t -> t.getPhase() == WildFlyPackageTask.Phase.FINALIZING).collect(Collectors.toList());
+
+                finalizingTasks = CollectionUtils.addAll(finalizingTasks, finalizingLineEndingTasks);
+                for (int i=0; i< finalizingLineEndingTasks.size(); i++) {
+                    finalizingTasksPkgs = CollectionUtils.add(finalizingTasksPkgs, pkg);
+                }
+
+                final List<LineEndingsTask> processingLineEndingTasks = pkgTasks.getLineEndings().stream().filter(t -> t.getPhase() == WildFlyPackageTask.Phase.PROCESSING).collect(Collectors.toList());
+                for (LineEndingsTask lineEnding : processingLineEndingTasks) {
+                    lineEnding.execute(this, pkg);
+                }
             }
             pkgProgressTracker.processed(pkg);
         }
@@ -1164,66 +1172,6 @@ public class WfInstallPlugin extends ProvisioningPluginWithOptions implements In
             } catch (IOException e) {
                 throw new ProvisioningException(Errors.mkdirs(installDir.resolve(dirName)));
             }
-        }
-    }
-
-    private static void changeLineEndings(final WildFlyPackageTasks tasks, final Path installDir) throws ProvisioningException {
-        // If not line end filters are present no need to walk the directory
-        if (tasks.getUnixLineEndFilters().isEmpty() && tasks.getWindowsLineEndFilters().isEmpty()) {
-            return;
-        }
-        try {
-            Files.walkFileTree(installDir, new SimpleFileVisitor<Path>() {
-                @Override
-                public FileVisitResult visitFile(final Path file, final BasicFileAttributes attrs) {
-                    final String relative = installDir.relativize(file).toString();
-                    for (FileFilter filter : tasks.getUnixLineEndFilters()) {
-                        if (filter.matches(relative)) {
-                            try {
-                                changeLineEndings(file, false);
-                            } catch (IOException e) {
-                                throw new UncheckedIOException(String.format("Failed to convert %s to Unix line endings.", file), e);
-                            }
-                        }
-                    }
-                    for (FileFilter filter : tasks.getWindowsLineEndFilters()) {
-                        if (filter.matches(relative)) {
-                            try {
-                                changeLineEndings(file, true);
-                            } catch (IOException e) {
-                                throw new UncheckedIOException(String.format("Failed to convert %s to Windows line endings.", file), e);
-                            }
-                        }
-                    }
-                    return FileVisitResult.CONTINUE;
-                }
-            });
-        } catch (UncheckedIOException e) {
-            throw new ProvisioningException(e.getMessage(), e.getCause());
-        } catch (IOException e) {
-            throw new ProvisioningException(String.format("Failed to process %s for files that require line ending changes.", installDir), e);
-        }
-    }
-
-    private static void changeLineEndings(final Path file, final boolean isWindows) throws IOException {
-        final String eol = (isWindows ? "\r\n" : "\n");
-        final Path temp = Files.createTempFile(file.getFileName().toString(), ".tmp");
-        // Copy the original file to the temporary file, replacing it and copying the attributes. Note that the order of
-        // REPLACE_EXISTING and COPY_ATTRIBUTES is important.
-        Files.copy(file, temp, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.COPY_ATTRIBUTES);
-        try (
-                BufferedReader reader = Files.newBufferedReader(temp, StandardCharsets.UTF_8);
-                BufferedWriter writer = Files.newBufferedWriter(file, StandardCharsets.UTF_8, StandardOpenOption.TRUNCATE_EXISTING)
-        ) {
-            // Process each line and write a eol string
-            String line;
-            while ((line = reader.readLine()) != null) {
-                writer.write(line);
-                writer.write(eol);
-            }
-
-        } finally {
-            Files.delete(temp);
         }
     }
 

--- a/galleon-plugins/src/main/java/org/wildfly/galleon/plugin/WildFlyPackageTasks.java
+++ b/galleon-plugins/src/main/java/org/wildfly/galleon/plugin/WildFlyPackageTasks.java
@@ -27,7 +27,7 @@ import javax.xml.stream.XMLStreamException;
 import org.jboss.galleon.Errors;
 import org.jboss.galleon.ProvisioningException;
 import org.jboss.galleon.util.CollectionUtils;
-import org.wildfly.galleon.plugin.config.FileFilter;
+import org.wildfly.galleon.plugin.config.LineEndingsTask;
 import org.wildfly.galleon.plugin.config.WildFlyPackageTasksParser;
 
 
@@ -40,8 +40,7 @@ public class WildFlyPackageTasks {
     public static class Builder {
 
         private List<String> mkDirs = Collections.emptyList();
-        private List<FileFilter> windowsLineEndFilters = Collections.emptyList();
-        private List<FileFilter> unixLineEndFilters = Collections.emptyList();
+        private List<LineEndingsTask> lineEndings = Collections.emptyList();
 
         private List<WildFlyPackageTask> tasks = Collections.emptyList();
 
@@ -58,13 +57,8 @@ public class WildFlyPackageTasks {
             return this;
         }
 
-        public Builder addWindowsLineEndFilter(FileFilter filter) {
-            windowsLineEndFilters = CollectionUtils.add(windowsLineEndFilters, filter);
-            return this;
-        }
-
-        public Builder addUnixLineEndFilter(FileFilter filter) {
-            unixLineEndFilters = CollectionUtils.add(unixLineEndFilters, filter);
+        public Builder addLineEndings(LineEndingsTask lineEndingsTask) {
+            lineEndings = CollectionUtils.add(lineEndings, lineEndingsTask);
             return this;
         }
 
@@ -88,14 +82,12 @@ public class WildFlyPackageTasks {
     }
 
     private final List<String> mkDirs;
-    private final List<FileFilter> windowsLineEndFilters;
-    private final List<FileFilter> unixLineEndFilters;
+    private final List<LineEndingsTask> lineEndings;
     private final List<WildFlyPackageTask> tasks;
 
     private WildFlyPackageTasks(Builder builder) {
         this.mkDirs = CollectionUtils.unmodifiable(builder.mkDirs);
-        this.windowsLineEndFilters = CollectionUtils.unmodifiable(builder.windowsLineEndFilters);
-        this.unixLineEndFilters = CollectionUtils.unmodifiable(builder.unixLineEndFilters);
+        this.lineEndings = CollectionUtils.unmodifiable(builder.lineEndings);
         this.tasks = CollectionUtils.unmodifiable(builder.tasks);
     }
 
@@ -107,12 +99,8 @@ public class WildFlyPackageTasks {
         return mkDirs;
     }
 
-    public List<FileFilter> getWindowsLineEndFilters() {
-        return windowsLineEndFilters;
-    }
-
-    public List<FileFilter> getUnixLineEndFilters() {
-        return unixLineEndFilters;
+    public List<LineEndingsTask> getLineEndings() {
+        return lineEndings;
     }
 
     public boolean hasTasks() {

--- a/galleon-plugins/src/main/java/org/wildfly/galleon/plugin/config/LineEndingsTask.java
+++ b/galleon-plugins/src/main/java/org/wildfly/galleon/plugin/config/LineEndingsTask.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2016-2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.galleon.plugin.config;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.List;
+
+import org.jboss.galleon.ProvisioningException;
+import org.jboss.galleon.runtime.PackageRuntime;
+import org.wildfly.galleon.plugin.WfInstallPlugin;
+import org.wildfly.galleon.plugin.WildFlyPackageTask;
+
+public class LineEndingsTask implements WildFlyPackageTask {
+
+   private final List<FileFilter> unixLineEndFilters;
+   private final List<FileFilter> windowsLineEndFilters;
+   private Phase phase;
+
+   public LineEndingsTask(List<FileFilter> unixLineEndFilters, List<FileFilter> windowsLineEndFilters, Phase phase) {
+      this.unixLineEndFilters = unixLineEndFilters;
+      this.windowsLineEndFilters = windowsLineEndFilters;
+      this.phase = phase;
+   }
+
+   @Override
+   public Phase getPhase() {
+      return phase;
+   }
+
+   @Override
+   public void execute(WfInstallPlugin plugin, PackageRuntime pkg) throws ProvisioningException {
+      final Path installDir = plugin.getRuntime().getStagedDir();
+
+      // If not line end filters are present no need to walk the directory
+      if (unixLineEndFilters.isEmpty() && windowsLineEndFilters.isEmpty()) {
+         return;
+      }
+      try {
+         Files.walkFileTree(installDir, new SimpleFileVisitor<Path>() {
+            @Override
+            public FileVisitResult visitFile(final Path file, final BasicFileAttributes attrs) {
+               final String relative = installDir.relativize(file).toString();
+               for (FileFilter filter : unixLineEndFilters) {
+                  if (filter.matches(relative)) {
+                     try {
+                        changeLineEndings(file, false);
+                     } catch (IOException e) {
+                        throw new UncheckedIOException(String.format("Failed to convert %s to Unix line endings.", file), e);
+                     }
+                  }
+               }
+               for (FileFilter filter : windowsLineEndFilters) {
+                  if (filter.matches(relative)) {
+                     try {
+                        changeLineEndings(file, true);
+                     } catch (IOException e) {
+                        throw new UncheckedIOException(String.format("Failed to convert %s to Windows line endings.", file), e);
+                     }
+                  }
+               }
+               return FileVisitResult.CONTINUE;
+            }
+         });
+      } catch (UncheckedIOException e) {
+         throw new ProvisioningException(e.getMessage(), e.getCause());
+      } catch (IOException e) {
+         throw new ProvisioningException(String.format("Failed to process %s for files that require line ending changes.", installDir), e);
+      }
+
+   }
+
+   private static void changeLineEndings(final Path file, final boolean isWindows) throws IOException {
+      final String eol = (isWindows ? "\r\n" : "\n");
+      final Path temp = Files.createTempFile(file.getFileName().toString(), ".tmp");
+      // Copy the original file to the temporary file, replacing it and copying the attributes. Note that the order of
+      // REPLACE_EXISTING and COPY_ATTRIBUTES is important.
+      Files.copy(file, temp, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.COPY_ATTRIBUTES);
+      try (
+         BufferedReader reader = Files.newBufferedReader(temp, StandardCharsets.UTF_8);
+         BufferedWriter writer = Files.newBufferedWriter(file, StandardCharsets.UTF_8, StandardOpenOption.TRUNCATE_EXISTING)
+      ) {
+         // Process each line and write a eol string
+         String line;
+         while ((line = reader.readLine()) != null) {
+            writer.write(line);
+            writer.write(eol);
+         }
+
+      } finally {
+         Files.delete(temp);
+      }
+   }
+}

--- a/galleon-plugins/src/main/java/org/wildfly/galleon/plugin/config/WildFlyPackageTasksParser.java
+++ b/galleon-plugins/src/main/java/org/wildfly/galleon/plugin/config/WildFlyPackageTasksParser.java
@@ -34,9 +34,11 @@ import org.wildfly.galleon.plugin.WildFlyPackageTasks;
 public class WildFlyPackageTasksParser {
     public static final String NAMESPACE_2_0 = "urn:wildfly:wildfly-feature-pack-tasks:2.0";
     public static final String NAMESPACE_3_0 = "urn:wildfly:wildfly-feature-pack-tasks:3.0";
+    public static final String NAMESPACE_3_1 = "urn:wildfly:wildfly-feature-pack-tasks:3.1";
 
     private static final QName ROOT_2_0 = new QName(NAMESPACE_2_0, WildFlyPackageTasksParser20.Element.TASKS.getLocalName());
     private static final QName ROOT_3_0 = new QName(NAMESPACE_3_0, WildFlyPackageTasksParser30.Element.TASKS.getLocalName());
+    private static final QName ROOT_3_1 = new QName(NAMESPACE_3_1, WildFlyPackageTasksParser31.Element.TASKS.getLocalName());
 
     private static final XMLInputFactory INPUT_FACTORY = XMLInputFactory.newInstance();
 
@@ -44,6 +46,7 @@ public class WildFlyPackageTasksParser {
 
     public WildFlyPackageTasksParser() {
         mapper = XMLMapper.Factory.create();
+        mapper.registerRootElement(ROOT_3_1, new WildFlyPackageTasksParser31());
         mapper.registerRootElement(ROOT_3_0, new WildFlyPackageTasksParser30());
         mapper.registerRootElement(ROOT_2_0, new WildFlyPackageTasksParser20());
     }

--- a/galleon-plugins/src/main/java/org/wildfly/galleon/plugin/config/WildFlyPackageTasksParser31.java
+++ b/galleon-plugins/src/main/java/org/wildfly/galleon/plugin/config/WildFlyPackageTasksParser31.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 Red Hat, Inc. and/or its affiliates
+ * Copyright 2016-2022 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,6 +17,17 @@
 
 package org.wildfly.galleon.plugin.config;
 
+import javax.xml.namespace.QName;
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
 import org.jboss.galleon.ProvisioningDescriptionException;
 import org.jboss.galleon.config.ConfigModel;
 import org.jboss.galleon.util.CollectionUtils;
@@ -28,19 +39,7 @@ import org.jboss.staxmapper.XMLExtendedStreamReader;
 import org.wildfly.galleon.plugin.WildFlyPackageTask;
 import org.wildfly.galleon.plugin.WildFlyPackageTasks;
 
-import javax.xml.namespace.QName;
-import javax.xml.stream.XMLStreamConstants;
-import javax.xml.stream.XMLStreamException;
-import javax.xml.stream.XMLStreamReader;
-
-import static org.wildfly.galleon.plugin.config.WildFlyPackageTasksParser.NAMESPACE_3_0;
-
-import java.util.Collections;
-import java.util.EnumSet;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import static org.wildfly.galleon.plugin.config.WildFlyPackageTasksParser.NAMESPACE_3_1;
 
 /**
  * Parses the WildFly-based feature pack build config file (i.e. the config file that is
@@ -51,7 +50,7 @@ import java.util.Set;
  * @author Alexey Loubyansky
  * @author Emmanuel Hugonnet
  */
-class WildFlyPackageTasksParser30 implements XMLElementReader<WildFlyPackageTasks.Builder> {
+class WildFlyPackageTasksParser31 implements XMLElementReader<WildFlyPackageTasks.Builder> {
 
     enum Element {
 
@@ -82,32 +81,32 @@ class WildFlyPackageTasksParser30 implements XMLElementReader<WildFlyPackageTask
 
         static {
             Map<QName, Element> elementsMap = new HashMap<>(19);
-            elementsMap.put(new QName(NAMESPACE_3_0, Element.CONFIG.getLocalName()), Element.CONFIG);
-            elementsMap.put(new QName(NAMESPACE_3_0, Element.COPY_ARTIFACT.getLocalName()), Element.COPY_ARTIFACT);
-            elementsMap.put(new QName(NAMESPACE_3_0, Element.COPY_PATH.getLocalName()), Element.COPY_PATH);
-            elementsMap.put(new QName(NAMESPACE_3_0, Element.DELETE.getLocalName()), Element.DELETE);
-            elementsMap.put(new QName(NAMESPACE_3_0, Element.EXAMPLE_CONFIGS.getLocalName()), Element.EXAMPLE_CONFIGS);
-            elementsMap.put(new QName(NAMESPACE_3_0, Element.FILE_APPENDER.getLocalName()), Element.FILE_APPENDER);
-            elementsMap.put(new QName(NAMESPACE_3_0, Element.FILE_PERMISSIONS.getLocalName()), Element.FILE_PERMISSIONS);
-            elementsMap.put(new QName(NAMESPACE_3_0, Element.FILTER.getLocalName()), Element.FILTER);
-            elementsMap.put(new QName(NAMESPACE_3_0, Element.LINE.getLocalName()), Element.LINE);
-            elementsMap.put(new QName(NAMESPACE_3_0, Element.LINE_ENDINGS.getLocalName()), Element.LINE_ENDINGS);
-            elementsMap.put(new QName(NAMESPACE_3_0, Element.MKDIR.getLocalName()), Element.MKDIR);
-            elementsMap.put(new QName(NAMESPACE_3_0, Element.PARAM.getLocalName()), Element.PARAM);
-            elementsMap.put(new QName(NAMESPACE_3_0, Element.PARAMS.getLocalName()), Element.PARAMS);
-            elementsMap.put(new QName(NAMESPACE_3_0, Element.PERMISSION.getLocalName()), Element.PERMISSION);
-            elementsMap.put(new QName(NAMESPACE_3_0, Element.TASKS.getLocalName()), Element.TASKS);
-            elementsMap.put(new QName(NAMESPACE_3_0, Element.TRANSFORM.getLocalName()), Element.TRANSFORM);
-            elementsMap.put(new QName(NAMESPACE_3_0, Element.UNIX.getLocalName()), Element.UNIX);
-            elementsMap.put(new QName(NAMESPACE_3_0, Element.WINDOWS.getLocalName()), Element.WINDOWS);
-            elementsMap.put(new QName(NAMESPACE_3_0, Element.XML_MERGE.getLocalName()), Element.XML_MERGE);
+            elementsMap.put(new QName(NAMESPACE_3_1, Element.CONFIG.getLocalName()), Element.CONFIG);
+            elementsMap.put(new QName(NAMESPACE_3_1, Element.COPY_ARTIFACT.getLocalName()), Element.COPY_ARTIFACT);
+            elementsMap.put(new QName(NAMESPACE_3_1, Element.COPY_PATH.getLocalName()), Element.COPY_PATH);
+            elementsMap.put(new QName(NAMESPACE_3_1, Element.DELETE.getLocalName()), Element.DELETE);
+            elementsMap.put(new QName(NAMESPACE_3_1, Element.EXAMPLE_CONFIGS.getLocalName()), Element.EXAMPLE_CONFIGS);
+            elementsMap.put(new QName(NAMESPACE_3_1, Element.FILE_APPENDER.getLocalName()), Element.FILE_APPENDER);
+            elementsMap.put(new QName(NAMESPACE_3_1, Element.FILE_PERMISSIONS.getLocalName()), Element.FILE_PERMISSIONS);
+            elementsMap.put(new QName(NAMESPACE_3_1, Element.FILTER.getLocalName()), Element.FILTER);
+            elementsMap.put(new QName(NAMESPACE_3_1, Element.LINE.getLocalName()), Element.LINE);
+            elementsMap.put(new QName(NAMESPACE_3_1, Element.LINE_ENDINGS.getLocalName()), Element.LINE_ENDINGS);
+            elementsMap.put(new QName(NAMESPACE_3_1, Element.MKDIR.getLocalName()), Element.MKDIR);
+            elementsMap.put(new QName(NAMESPACE_3_1, Element.PARAM.getLocalName()), Element.PARAM);
+            elementsMap.put(new QName(NAMESPACE_3_1, Element.PARAMS.getLocalName()), Element.PARAMS);
+            elementsMap.put(new QName(NAMESPACE_3_1, Element.PERMISSION.getLocalName()), Element.PERMISSION);
+            elementsMap.put(new QName(NAMESPACE_3_1, Element.TASKS.getLocalName()), Element.TASKS);
+            elementsMap.put(new QName(NAMESPACE_3_1, Element.TRANSFORM.getLocalName()), Element.TRANSFORM);
+            elementsMap.put(new QName(NAMESPACE_3_1, Element.UNIX.getLocalName()), Element.UNIX);
+            elementsMap.put(new QName(NAMESPACE_3_1, Element.WINDOWS.getLocalName()), Element.WINDOWS);
+            elementsMap.put(new QName(NAMESPACE_3_1, Element.XML_MERGE.getLocalName()), Element.XML_MERGE);
             elements = elementsMap;
         }
 
         static Element of(QName qName) {
             QName name;
             if (qName.getNamespaceURI().equals("")) {
-                name = new QName(NAMESPACE_3_0, qName.getLocalPart());
+                name = new QName(NAMESPACE_3_1, qName.getLocalPart());
             } else {
                 name = qName;
             }
@@ -364,12 +363,24 @@ class WildFlyPackageTasksParser30 implements XMLElementReader<WildFlyPackageTask
     }
 
     private void parseLineEndings(final XMLStreamReader reader, final WildFlyPackageTasks.Builder builder) throws XMLStreamException {
+        WildFlyPackageTask.Phase phase = WildFlyPackageTask.Phase.PROCESSING;
+        for (int i=0; i<reader.getAttributeCount(); i++) {
+            final Attribute attribute = Attribute.of(reader.getAttributeName(i));
+            switch (attribute) {
+                case PHASE:
+                    phase = WildFlyPackageTask.Phase.valueOf(reader.getAttributeValue(i).toUpperCase());
+                    break;
+                default:
+                    throw ParsingUtils.unexpectedContent(reader);
+            }
+        }
+
         List<FileFilter> unixLineEndFilters = Collections.emptyList();
         List<FileFilter> windowsLineEndFilters = Collections.emptyList();
         while (reader.hasNext()) {
             switch (reader.nextTag()) {
                 case XMLStreamConstants.END_ELEMENT: {
-                    final LineEndingsTask lineEndingsTask = new LineEndingsTask(unixLineEndFilters, windowsLineEndFilters, WildFlyPackageTask.Phase.PROCESSING);
+                    final LineEndingsTask lineEndingsTask = new LineEndingsTask(unixLineEndFilters, windowsLineEndFilters, phase);
                     builder.addLineEndings(lineEndingsTask);
                     return;
                 }

--- a/maven-plugin/src/main/resources/schema/wildfly-feature-pack-tasks-3_1.xsd
+++ b/maven-plugin/src/main/resources/schema/wildfly-feature-pack-tasks-3_1.xsd
@@ -1,0 +1,436 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+
+    Copyright 2016-2021 Red Hat, Inc. and/or its affiliates
+    and other contributors as indicated by the @author tags.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<xs:schema xmlns="urn:wildfly:wildfly-feature-pack-tasks:3.1" xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  attributeFormDefault="unqualified" elementFormDefault="qualified" targetNamespace="urn:wildfly:wildfly-feature-pack-tasks:3.1"
+  version="2.0">
+ <xs:element name="tasks" type="tasksType" />
+ <xs:complexType name="tasksType">
+    <xs:annotation>
+      <xs:documentation>
+        List of tasks
+      </xs:documentation>
+    </xs:annotation>
+    <xs:choice maxOccurs="unbounded" minOccurs="0">
+      <xs:element name="append-file" type="appendFileType" />
+      <xs:element name="copy-artifact" type="copyArtifactType" />
+      <xs:element name="copy-path" type="copyPathType" />
+      <xs:element name="delete" type="deleteType" />
+      <xs:element name="file-permissions" type="filePermissionsType" />
+      <xs:element name="line-endings" type="lineEndingsType" />
+      <xs:element name="mkdir" type="mkdirType" />
+      <xs:element name="transform" type="transformType" />
+      <xs:element name="xml-merge" type="xmlMergeType" />
+    </xs:choice>
+  </xs:complexType>
+
+  <xs:complexType name="appendFileType">
+    <xs:annotation>
+      <xs:documentation>
+        Append some content to an existing file. This task can append content at the end of the file or at a given location according to a pattern.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:choice maxOccurs="unbounded" minOccurs="0">
+        <xs:element name="line" type="lineType" />
+    </xs:choice>
+    <xs:attribute name="add-to-matching-line" type="xs:string" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          Content to add at the end of the line that matches.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="all-matches" type="xs:boolean" use="optional" default="true">
+      <xs:annotation>
+        <xs:documentation>
+           If set to false, content is added for each match.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="ignore" type="xs:boolean" use="optional" default="true">
+      <xs:annotation>
+        <xs:documentation>
+          If set to false, the task is ignored if the target file doesn't exist.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="match" type="xs:string" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          A pattern used to match the line where the content to add is to be added after.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="src" type="xs:string" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          A path relative to the server installation that has already been installed when this tasks executes. It contains the content to append to the `target` file.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="target" type="xs:string" use="required">
+      <xs:annotation>
+        <xs:documentation>
+          A file path relative to the server installation to append content to.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+  
+  <xs:complexType name="lineType">
+    <xs:annotation>
+      <xs:documentation>
+        Contains a line of content.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:simpleContent>
+      <xs:extension base="xs:string">
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  
+  <xs:complexType name="copyArtifactType">
+    <xs:annotation>
+      <xs:documentation>
+        Copy a maven artifact to a server installation location. In order to retrieve the artifact version, the artifact must be declared as a maven dependency of the feature-pack.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:choice maxOccurs="unbounded" minOccurs="0">
+        <xs:element name="filter" type="filterType" />
+    </xs:choice>
+    <xs:attribute name="artifact" type="xs:string" use="required">
+      <xs:annotation>
+        <xs:documentation>
+          Artifact maven coordinates in the form : 'groupId:artifactid[:version][:classifier][:extension]'
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="extract" type="xs:boolean" use="optional" default="false">
+      <xs:annotation>
+        <xs:documentation>
+           Extract the artifact to a directory. A set of filters can be defined in order to include and/or exclude content from the extracted artifact.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="feature-pack-version" type="xs:boolean" use="optional" default="false">
+      <xs:annotation>
+        <xs:documentation>
+           If set to true, the artifact version will be retrieved from the dependencies of the feature-pack that defines the task.xml. If false, all feature-packs in the feature-pack dependency tree are looked-up.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="optional" type="xs:boolean" use="optional" default="false">
+      <xs:annotation>
+        <xs:documentation>
+           If set to true, if the artifact is not found in the feature-pack dependency, the task is ignored
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="to-location" type="xs:string" use="required">
+      <xs:annotation>
+        <xs:documentation>
+          Relative path within the server installation. Target file must be a directory if 'extract' is true. 
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+
+  <xs:complexType name="filterType">
+    <xs:annotation>
+      <xs:documentation>
+        A filter to include/exclude files.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:attribute name="include" type="xs:boolean" use="optional" default="false">
+      <xs:annotation>
+        <xs:documentation>
+           If true, the matching files are included. If false the matching files are excluded.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="pattern" type="xs:string" use="required">
+      <xs:annotation>
+        <xs:documentation>
+          The pattern to match files.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+
+  <xs:complexType name="copyPathType">
+    <xs:annotation>
+      <xs:documentation>
+        Copy a path to a server installation location.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:attribute name="relative-to" type="xs:string" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          'content' is the only supported value. When set to 'content' the 'src' path must be located inside 'package_name/content'
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="replace-props" type="xs:string" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          When copying files, the properties contained in copied files are replaced with values retrieved from the tasks properties.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="src" type="xs:string" use="required">
+      <xs:annotation>
+        <xs:documentation>
+          Path to the file or directory to copy. If 'relative-to' is not set, the path must be located inside 'package_name/pm/wildfly'.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="target" type="xs:string" use="required">
+      <xs:annotation>
+        <xs:documentation>
+          Relative path within the server installation to the target.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+  
+  <xs:complexType name="deleteType">
+    <xs:annotation>
+      <xs:documentation>
+        Delete a path from the server installation.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:attribute name="if-empty" type="xs:boolean" use="optional" default="false">
+      <xs:annotation>
+        <xs:documentation>
+           Deletion only occurs if the directory is empty, otherwise deletion is ignored. If set to true, the 'path' must be a directory. 
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="path" type="xs:string" use="required">
+      <xs:annotation>
+        <xs:documentation>
+          Path relative to the server installation to delete. Can be a file or a directory. If the file doesn't exist, deletion is ignored.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="recursive" type="xs:boolean" use="optional" default="false">
+      <xs:annotation>
+        <xs:documentation>
+           If set to true, if the path is a directory it is deleted recursively.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+  
+  <xs:complexType name="filePermissionsType">
+    <xs:annotation>
+      <xs:documentation>
+        Set the permissions on a set of files.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:choice maxOccurs="unbounded" minOccurs="0">
+        <xs:element name="permission" type="permissionType" />
+    </xs:choice>
+    <xs:attribute name="phase" type="xs:string" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          By default this task runs in the 'PROCESSING' phase (when the package is provisioned). If set to 'FINALIZING', the tasks will be run once the server has been fully provisioned.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+  
+  <xs:complexType name="permissionType">
+    <xs:annotation>
+      <xs:documentation>
+        Contains the file permission value and the set of files.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:choice maxOccurs="unbounded" minOccurs="0">
+        <xs:element name="filter" type="filterType" />
+    </xs:choice>
+    <xs:attribute name="value" type="xs:string" use="required">
+      <xs:annotation>
+        <xs:documentation>
+           Linux permissions to Execute, Write and Read for USER, GROUP and OTHERS. eg: '777' to grant all permissions to all.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+  
+  <xs:complexType name="lineEndingsType">
+    <xs:annotation>
+      <xs:documentation>
+        Change the end of line for a set of files.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:choice maxOccurs="unbounded" minOccurs="0">
+        <xs:element name="unix" type="unixType" />
+        <xs:element name="windows" type="windowsType" />
+    </xs:choice>
+    <xs:attribute name="phase" type="xs:string" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          By default this task runs in the 'PROCESSING' phase (when the package is provisioned). If set to 'FINALIZING', the tasks will be run once the server has been fully provisioned.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+  
+  <xs:complexType name="unixType">
+    <xs:annotation>
+      <xs:documentation>
+        Change the end of line for a set of files. "\n" is used as end of line.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:choice maxOccurs="unbounded" minOccurs="0">
+        <xs:element name="filter" type="filterType" />
+    </xs:choice>
+  </xs:complexType>
+  
+  <xs:complexType name="windowsType">
+    <xs:annotation>
+      <xs:documentation>
+        Change the end of line for a set of files. "\r\n" is used as end of line.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:choice maxOccurs="unbounded" minOccurs="0">
+        <xs:element name="filter" type="filterType" />
+    </xs:choice>
+  </xs:complexType>
+  
+  <xs:complexType name="mkdirType">
+    <xs:annotation>
+      <xs:documentation>
+        Create a directory inside the server installation.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:attribute name="name" type="xs:string" use="required">
+      <xs:annotation>
+        <xs:documentation>
+          Path to the directory to create.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+  
+  <xs:complexType name="transformType">
+    <xs:annotation>
+      <xs:documentation>
+        XSL transformation of XML type.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:choice maxOccurs="unbounded" minOccurs="0">
+        <xs:element name="params" type="paramsType" />
+    </xs:choice>
+    <xs:attribute name="feature-pack-properties" type="xs:boolean" use="optional" default="false">
+      <xs:annotation>
+        <xs:documentation>
+            If set to false, the properties are resolved from the merged tasks properties found in the feature-pack dependencies. If true, the tasks properties defined in the feature-pack that defines the task are used.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="output" type="xs:string" use="required">
+      <xs:annotation>
+        <xs:documentation>
+          Relative path to the transformed XML document.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="phase" type="xs:string" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          By default this task runs in the 'PROCESSING' phase (when the package is provisioned). If set to 'FINALIZING', the tasks will be run once the server has been fully provisioned.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="src" type="xs:string" use="required">
+      <xs:annotation>
+        <xs:documentation>
+          Relative path to the XML document to transform.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="stylesheet" type="xs:string" use="required">
+      <xs:annotation>
+        <xs:documentation>
+          Relative path to the stylesheet file.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+  
+  <xs:complexType name="paramsType">
+    <xs:annotation>
+      <xs:documentation>
+        List of parameters to convey to the XSL transformer
+      </xs:documentation>
+    </xs:annotation>
+    <xs:choice maxOccurs="unbounded" minOccurs="0">
+        <xs:element name="param" type="paramType" />
+    </xs:choice>
+  </xs:complexType>
+  
+  <xs:complexType name="paramType">
+    <xs:annotation>
+      <xs:documentation>
+        An XSL transformer parameter.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:attribute name="name" type="xs:string" use="required">
+      <xs:annotation>
+        <xs:documentation>
+           Parameter name.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="value" type="xs:string" use="required">
+      <xs:annotation>
+        <xs:documentation>
+           Parameter value.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+  
+  <xs:complexType name="xmlMergeType">
+    <xs:annotation>
+      <xs:documentation>
+        Merge a set of XML files into an XML file. This tasks expects the file 'merger.xsl' to be present in 'package_name/pm/wildfly/' directory.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:choice maxOccurs="unbounded" minOccurs="0">
+        <xs:element name="filter" type="filterType" />
+    </xs:choice>
+    <xs:attribute name="basedir" type="xs:string" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          The directory inside the server installation that contains the files to merge. If not specified the server root dir is used.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="output" type="xs:string" use="required">
+      <xs:annotation>
+        <xs:documentation>
+          The relative path inside the server installation to the merged XML file.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+</xs:schema>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFGP-232

This would allow to run the line-ending filter after FINALIZING phase tasks like this:

```
<tasks xmlns="urn:wildfly:wildfly-feature-pack-tasks:3.1">
    <delete path="docs/licenses/licenses.html"/>
    <xml-merge basedir="docs/licenses" output="docs/licenses/licenses.xml">
        <filter pattern="*-licenses.xml" include="true"/>
    </xml-merge>
    <transform stylesheet="docs/licenses/licenses.xsl" src="docs/licenses/licenses.xml" output="docs/licenses/licenses.html" phase="FINALIZING"/>
    <line-endings phase="FINALIZING">
      <unix>
        <filter pattern="docs/licenses/licenses.html" include="true"/>
      </unix>
    </line-endings>
</tasks>
```