### PR TITLE
 Fix for WFGP-233, JBoss Modules aliases are not provisioned when Galleon provisions the target module

### DIFF
--- a/maven-plugin/src/main/java/org/wildfly/galleon/maven/AbstractFeaturePackBuildMojo.java
+++ b/maven-plugin/src/main/java/org/wildfly/galleon/maven/AbstractFeaturePackBuildMojo.java
@@ -724,7 +724,14 @@ public abstract class AbstractFeaturePackBuildMojo extends AbstractMojo {
     private void packageModules(FeaturePackDescription.Builder fpBuilder,
             Path resourcesDir, Map<String, Path> moduleXmlByPkgName, PackageSpec.Builder modulesAll)
             throws IOException, MojoExecutionException {
-
+        Map<ModuleIdentifier, Set<ModuleIdentifier>> targetToAlias = new HashMap<>();
+        for (Map.Entry<String, Path> module : moduleXmlByPkgName.entrySet()) {
+            try {
+                ModuleXmlParser.populateAlias(module.getValue(), WfConstants.UTF8, targetToAlias);
+            } catch (ParsingException e) {
+                throw new IOException(Errors.parseXml(module.getValue()), e);
+            }
+        }
         for (Map.Entry<String, Path> module : moduleXmlByPkgName.entrySet()) {
             final String packageName = module.getKey();
             final Path moduleXml = module.getValue();
@@ -737,7 +744,7 @@ public abstract class AbstractFeaturePackBuildMojo extends AbstractMojo {
             final PackageSpec.Builder pkgSpecBuilder = PackageSpec.builder(packageName);
             final ModuleParseResult parsedModule;
             try {
-                parsedModule = ModuleXmlParser.parse(targetXml, WfConstants.UTF8);
+                parsedModule = ModuleXmlParser.parse(targetXml, WfConstants.UTF8, targetToAlias);
                 if (!parsedModule.dependencies.isEmpty()) {
                     for (ModuleParseResult.ModuleDependency moduleDep : parsedModule.dependencies) {
                         final ModuleIdentifier moduleId = moduleDep.getModuleId();

--- a/maven-plugin/src/main/java/org/wildfly/galleon/maven/ModuleXmlParser.java
+++ b/maven-plugin/src/main/java/org/wildfly/galleon/maven/ModuleXmlParser.java
@@ -76,20 +76,25 @@ class ModuleXmlParser {
         final String targetName = getOptionalAttributeValue(element, "target-name", "");
         final String targetSlot = getOptionalAttributeValue(element, "target-slot", "main");
         final String name = element.getAttributeValue("name");
-        ModuleIdentifier targetModuleId = new ModuleIdentifier(targetName, targetSlot);
+        ModuleIdentifier targetModuleId = getModuleIdentifier(targetName, targetSlot);
         Set<ModuleIdentifier> aliases = targetToAlias.get(targetModuleId);
         if (aliases == null) {
             aliases = new HashSet<>();
             targetToAlias.put(targetModuleId, aliases);
         }
-        ModuleIdentifier aliasModuleId;
-        if (name.indexOf(':') < 0) {
-            final String slot = getOptionalAttributeValue(element, "slot", "main");
-            aliasModuleId = new ModuleIdentifier(name, slot);
-        } else {
-            aliasModuleId = ModuleIdentifier.fromString(name);
-        }
+        final String slot = getOptionalAttributeValue(element, "slot", "main");
+        ModuleIdentifier aliasModuleId = getModuleIdentifier(name, slot);
         aliases.add(aliasModuleId);
+    }
+
+    private static ModuleIdentifier getModuleIdentifier(String name, String slot) {
+        ModuleIdentifier moduleId;
+        if (name.indexOf(':') < 0) {
+            moduleId = new ModuleIdentifier(name, slot);
+        } else {
+            moduleId = ModuleIdentifier.fromString(name);
+        }
+        return moduleId;
     }
 
     private static ModuleParseResult parse(final Reader r, Map<ModuleIdentifier, Set<ModuleIdentifier>> targetToAlias) throws IOException, ParsingException {
@@ -108,7 +113,7 @@ class ModuleXmlParser {
     private static void parseModule(Element element, ModuleParseResult result, Map<ModuleIdentifier, Set<ModuleIdentifier>> targetToAlias) throws ParsingException {
         String name = element.getAttributeValue("name");
         String slot = getOptionalAttributeValue(element, "slot", "main");
-        result.identifier = new ModuleIdentifier(name, slot);
+        result.identifier = getModuleIdentifier(name, slot);
         final Attribute versionAttribute = element.getAttribute("version");
         if (versionAttribute != null) {
             result.versionArtifactName = parseOptionalArtifactName(versionAttribute.getValue(), versionAttribute);
@@ -135,8 +140,8 @@ class ModuleXmlParser {
         final String targetSlot = getOptionalAttributeValue(element, "target-slot", "main");
         final String name = element.getAttributeValue("name");
         final String slot = getOptionalAttributeValue(element, "slot", "main");
-        ModuleIdentifier moduleId = new ModuleIdentifier(targetName, targetSlot);
-        result.identifier = new ModuleIdentifier(name, slot);
+        ModuleIdentifier moduleId = getModuleIdentifier(targetName, targetSlot);
+        result.identifier = getModuleIdentifier(name, slot);
         result.dependencies.add(new ModuleParseResult.ModuleDependency(moduleId, false, Collections.emptyMap()));
     }
 
@@ -146,13 +151,8 @@ class ModuleXmlParser {
         for (int i = 0; i < size; i ++) {
             final Element moduleElement = modules.get(i);
             final String name = getOptionalAttributeValue(moduleElement, "name", "");
-            final ModuleIdentifier moduleId;
-            if(name.indexOf(':') < 0) {
-                final String slot = getOptionalAttributeValue(moduleElement, "slot", "main");
-                moduleId = new ModuleIdentifier(name, slot);
-            } else {
-                moduleId = ModuleIdentifier.fromString(name);
-            }
+            final String slot = getOptionalAttributeValue(moduleElement, "slot", "main");
+            final ModuleIdentifier moduleId = getModuleIdentifier(name, slot);
             final boolean optional = Boolean.parseBoolean(getOptionalAttributeValue(moduleElement, "optional", "false"));
 
             final Element properties = moduleElement.getFirstChildElement("properties", moduleElement.getNamespaceURI());

--- a/maven-plugin/src/test/java/org/wildfly/galleon/maven/ModuleAliasTestCase.java
+++ b/maven-plugin/src/test/java/org/wildfly/galleon/maven/ModuleAliasTestCase.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2016-2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.galleon.maven;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+import org.wildfly.galleon.maven.ModuleParseResult.ModuleDependency;
+import org.wildfly.galleon.plugin.WfConstants;
+
+public class ModuleAliasTestCase {
+
+    @Test
+    public void testAlias() throws Exception {
+        StringBuilder moduleAlias1Content = new StringBuilder();
+        moduleAlias1Content.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>").append(System.lineSeparator());
+        moduleAlias1Content.append("<module-alias xmlns=\"urn:jboss:module:1.9\" name=\"org.foo.alias1\" target-name=\"org.target\"/>");
+        Map<ModuleIdentifier, Set<ModuleIdentifier>> map = new HashMap<>();
+        Path moduleAlias1File = Paths.get("module1.xml");
+        Files.write(moduleAlias1File, moduleAlias1Content.toString().getBytes());
+        ModuleIdentifier alias1Id = new ModuleIdentifier("org.foo.alias1", "main");
+
+        StringBuilder moduleAlias2Content = new StringBuilder();
+        moduleAlias2Content.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>").append(System.lineSeparator());
+        moduleAlias2Content.append("<module-alias xmlns=\"urn:jboss:module:1.9\" name=\"org.foo.alias1:2\" target-name=\"org.target\"/>");
+        Path moduleAlias2File = Paths.get("module2.xml");
+        Files.write(moduleAlias2File, moduleAlias2Content.toString().getBytes());
+        ModuleIdentifier alias2Id = ModuleIdentifier.fromString("org.foo.alias1:2");
+
+        StringBuilder moduleAlias3Content = new StringBuilder();
+        moduleAlias3Content.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>").append(System.lineSeparator());
+        moduleAlias3Content.append("<module-alias xmlns=\"urn:jboss:module:1.9\" name=\"org.foo.alias3\" target-name=\"org.target:2\"/>");
+        Path moduleAlias3File = Paths.get("module3.xml");
+        Files.write(moduleAlias3File, moduleAlias3Content.toString().getBytes());
+        ModuleIdentifier alias3Id = new ModuleIdentifier("org.foo.alias3", "main");
+
+        StringBuilder moduleTargetContent = new StringBuilder();
+        moduleTargetContent.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>").append(System.lineSeparator());
+        moduleTargetContent.append("<module xmlns=\"urn:jboss:module:1.9\" name=\"org.target\"/>");
+        Path moduleTargetContentFile = Paths.get("module-target.xml");
+        Files.write(moduleTargetContentFile, moduleTargetContent.toString().getBytes());
+
+        StringBuilder moduleTarget2Content = new StringBuilder();
+        moduleTarget2Content.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>").append(System.lineSeparator());
+        moduleTarget2Content.append("<module xmlns=\"urn:jboss:module:1.9\" name=\"org.target:2\"/>");
+        Path moduleTarget2ContentFile = Paths.get("module-target2.xml");
+        Files.write(moduleTarget2ContentFile, moduleTarget2Content.toString().getBytes());
+
+        try {
+            ModuleXmlParser.populateAlias(moduleAlias1File, WfConstants.UTF8, map);
+            ModuleXmlParser.populateAlias(moduleAlias2File, WfConstants.UTF8, map);
+            ModuleXmlParser.populateAlias(moduleAlias3File, WfConstants.UTF8, map);
+
+            ModuleParseResult res = ModuleXmlParser.parse(moduleTargetContentFile, WfConstants.UTF8, map);
+            int numDependencies = 2;
+            assertEquals(numDependencies, res.getDependencies().size());
+            for (ModuleDependency dep : res.getDependencies()) {
+                if (dep.getModuleId().equals(alias2Id) || dep.getModuleId().equals(alias1Id)) {
+                    numDependencies -= 1;
+                }
+            }
+            assertEquals(0, numDependencies);
+
+            ModuleParseResult res2 = ModuleXmlParser.parse(moduleTarget2ContentFile, WfConstants.UTF8, map);
+            numDependencies = 1;
+            assertEquals(numDependencies, res2.getDependencies().size());
+            for (ModuleDependency dep : res2.getDependencies()) {
+                if (dep.getModuleId().equals(alias3Id)) {
+                    numDependencies -= 1;
+                }
+            }
+            assertEquals(0, numDependencies);
+
+        } finally {
+            Files.deleteIfExists(moduleAlias1File);
+            Files.deleteIfExists(moduleAlias2File);
+            Files.deleteIfExists(moduleAlias3File);
+            Files.deleteIfExists(moduleTargetContentFile);
+            Files.deleteIfExists(moduleTarget2ContentFile);
+        }
+
+    }
+}


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFGP-233

In addition to the fix, the parsing of module name that contain the slot has been extended to cover all JBoss Module modules names.