### PR TITLE
[WFGP-245] improve progress tracking

### DIFF
--- a/config-gen/src/main/java/org/wildfly/galleon/plugin/config/generator/WfConfigGenerator.java
+++ b/config-gen/src/main/java/org/wildfly/galleon/plugin/config/generator/WfConfigGenerator.java
@@ -164,14 +164,15 @@ public class WfConfigGenerator extends BaseConfigGenerator {
                 config.handle(configHandler);
                 progressTracker.processed(config);
             }
-            progressTracker.complete();
         }
 
         if(forkEmbedded) {
+            progressTracker.processing(null);
             scriptWriter.close();
             scriptWriter = null;
             ForkedEmbeddedUtil.fork(new ForkedConfigGenerator(), jbossHome, script.toString());
         }
+        progressTracker.complete();
     }
 
     private void cleanup(Map<?, ?> originalProps) {

--- a/galleon-plugins/src/main/java/org/wildfly/galleon/plugin/MonitorableArtifact.java
+++ b/galleon-plugins/src/main/java/org/wildfly/galleon/plugin/MonitorableArtifact.java
@@ -1,0 +1,124 @@
+package org.wildfly.galleon.plugin;
+
+import org.jboss.galleon.progresstracking.ProgressTracker;
+import org.jboss.galleon.universe.maven.MavenArtifact;
+import org.jboss.galleon.universe.maven.MavenUniverseException;
+
+import java.nio.file.Path;
+
+class MonitorableArtifact extends MavenArtifact {
+
+    private final ProgressTracker<MavenArtifact> tracker;
+    private final MavenArtifact delegate;
+
+    MonitorableArtifact(MavenArtifact delegate, ProgressTracker<MavenArtifact> tracker) {
+        this.delegate = delegate;
+        this.tracker = tracker;
+    }
+
+    @Override
+    public String getGroupId() {
+        return delegate.getGroupId();
+    }
+
+    @Override
+    public MavenArtifact setGroupId(String groupId) {
+        return delegate.setGroupId(groupId);
+    }
+
+    @Override
+    public String getArtifactId() {
+        return delegate.getArtifactId();
+    }
+
+    @Override
+    public MavenArtifact setArtifactId(String artifactId) {
+        return delegate.setArtifactId(artifactId);
+    }
+
+    @Override
+    public boolean hasVersion() {
+        return delegate.hasVersion();
+    }
+
+    @Override
+    public String getVersion() {
+        return delegate.getVersion();
+    }
+
+    @Override
+    public MavenArtifact setVersion(String version) {
+        return delegate.setVersion(version);
+    }
+
+    @Override
+    public String getClassifier() {
+        return delegate.getClassifier();
+    }
+
+    @Override
+    public MavenArtifact setClassifier(String classifier) {
+        return delegate.setClassifier(classifier);
+    }
+
+    @Override
+    public String getExtension() {
+        return delegate.getExtension();
+    }
+
+    @Override
+    public MavenArtifact setExtension(String extension) {
+        return delegate.setExtension(extension);
+    }
+
+    @Override
+    public String getVersionRange() {
+        return delegate.getVersionRange();
+    }
+
+    @Override
+    public MavenArtifact setVersionRange(String versionRange) {
+        return delegate.setVersionRange(versionRange);
+    }
+
+    @Override
+    public Path getPath() {
+        return delegate.getPath();
+    }
+
+    @Override
+    public boolean isResolved() {
+        return delegate.isResolved();
+    }
+
+    @Override
+    public String getArtifactFileName() throws MavenUniverseException {
+        return delegate.getArtifactFileName();
+    }
+
+    @Override
+    public String getCoordsAsString() {
+        return delegate.getCoordsAsString();
+    }
+
+    @Override
+    public String toString() {
+        return delegate.toString();
+    }
+
+    @Override
+    public int hashCode() {
+        return delegate.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return delegate.equals(obj);
+    }
+
+    @Override
+    public MavenArtifact setPath(Path localArtifact) {
+        tracker.processed(delegate);
+        return delegate.setPath(localArtifact);
+    }
+}


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFGP-245

Adding two new trackers to the WfInstallPlugin to provide updates on bulk resolving artifacts and hide generating 2nd server to create examples.

@jfdenise l I'm not sure if that's a correct way to use the ProgressTrackers, could you take a look at this when you have a moment?