### PR TITLE
[WFGP-250] Include the artifact metadata when wrapping artifacts

### DIFF
--- a/galleon-plugins/src/main/java/org/wildfly/galleon/plugin/MonitorableArtifact.java
+++ b/galleon-plugins/src/main/java/org/wildfly/galleon/plugin/MonitorableArtifact.java
@@ -5,6 +5,7 @@ import org.jboss.galleon.universe.maven.MavenArtifact;
 import org.jboss.galleon.universe.maven.MavenUniverseException;
 
 import java.nio.file.Path;
+import java.util.Map;
 
 class MonitorableArtifact extends MavenArtifact {
 
@@ -99,6 +100,16 @@ class MonitorableArtifact extends MavenArtifact {
     @Override
     public String getCoordsAsString() {
         return delegate.getCoordsAsString();
+    }
+
+    @Override
+    public Map<String, String> getMetadata() {
+        return delegate.getMetadata();
+    }
+
+    @Override
+    public void addMetadata(String key, String value) {
+        delegate.addMetadata(key, value);
     }
 
     @Override


### PR DESCRIPTION
The MavenArtifacts are wrapped in MonitorableArtifacts before being resolved. The Metadata needs to be exposed in MonitorableArtifacts to allow the resolver to determine if channels are needed.

issue: https://issues.redhat.com/browse/WFGP-250](https://issues.redhat.com/browse/WFGP-250
