### PR TITLE
[WFGP-253] Use URIs instead of file paths when setting up XmlMerge

### DIFF
--- a/galleon-plugins/src/main/java/org/wildfly/galleon/plugin/config/XmlMerge.java
+++ b/galleon-plugins/src/main/java/org/wildfly/galleon/plugin/config/XmlMerge.java
@@ -96,7 +96,7 @@ public class XmlMerge implements WildFlyPackageTask {
                     if(buf.length() > 0) {
                         buf.append(',');
                     }
-                    buf.append(p.toString());
+                    buf.append(p.toUri().toString());
                 }
             }
         } catch (IOException e) {


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFGP-253

Convert file paths to URIs before passing them into XSL to escape special characters. XSL document() function extects the argument to be URI
