### PR TITLE
[WFGP-259] Use the native FS path as the moduleTemplates map key, not the…

### DIFF
--- a/maven-plugin/src/main/java/org/wildfly/galleon/maven/FeatureSpecGeneratorInvoker.java
+++ b/maven-plugin/src/main/java/org/wildfly/galleon/maven/FeatureSpecGeneratorInvoker.java
@@ -632,8 +632,10 @@ public class FeatureSpecGeneratorInvoker {
                         throws IOException {
                         if (WfConstants.MODULE_XML.equals(file.getFileName().toString())) {
                             final String relativePath = source.relativize(file).toString();
-                            moduleTemplates.put(relativePath, fpArtifacts);
-                            Files.copy(file, moduleTemplatesDir.resolve(relativePath), StandardCopyOption.REPLACE_EXISTING);
+                            Path nativeCopy = Files.copy(file, moduleTemplatesDir.resolve(relativePath), StandardCopyOption.REPLACE_EXISTING);
+                            // Use the native FS path as the map key, not the source path, which may be from ZipFileSystem
+                            // and won't match the path of the actual template file we just wrote
+                            moduleTemplates.put(moduleTemplatesDir.relativize(nativeCopy).toString(), fpArtifacts);
                         } else {
                             final Path target = wildflyHome.resolve(MODULES).resolve(source.relativize(file).toString());
                             Files.createDirectories(target.getParent());


### PR DESCRIPTION
… source path

The source path may come from ZipFileSystem and might not use the same separator char as the native FS file where the module template is stored

https://issues.redhat.com/browse/WFGP-259