### PR TITLE
Version 7.x depends on Galleon 6.x, enforce Layer check at build time

### DIFF
--- a/config-gen/pom.xml
+++ b/config-gen/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.wildfly.galleon-plugins</groupId>
     <artifactId>wildfly-provisioning-parent</artifactId>
-    <version>6.5.4.Final-SNAPSHOT</version>
+    <version>7.0.0.Beta1-SNAPSHOT</version>
   </parent>
 
   <artifactId>wildfly-config-gen</artifactId>

--- a/docs/guide/examples/user-defined-feature-pack/content.adoc
+++ b/docs/guide/examples/user-defined-feature-pack/content.adoc
@@ -25,7 +25,7 @@ Add the Maven plugin dependency in your pom.xml file :
   <dependency>
     <groupId>org.wildfly.galleon-plugins</groupId>
     <artifactId>wildfly-galleon-maven-plugin</artifactId>
-    <version>6.5.4.Final-SNAPSHOT</version>
+    <version>7.0.0.Beta1-SNAPSHOT</version>
   </dependency>
 </dependencies>
 ----

--- a/docs/guide/maven-plugins/index.adoc
+++ b/docs/guide/maven-plugins/index.adoc
@@ -10,7 +10,7 @@ include::provision-dist/index.adoc[]
 <dependency>
     <groupId>org.wildfly.galleon-plugins</groupId>
     <artifactId>wildfly-galleon-maven-plugin</artifactId>
-    <version>6.5.4.Final-SNAPSHOT</version>
+    <version>7.0.0.Beta1-SNAPSHOT</version>
 </dependency>
 ----
 

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.wildfly.galleon-plugins</groupId>
     <artifactId>wildfly-provisioning-parent</artifactId>
-    <version>6.5.4.Final-SNAPSHOT</version>
+    <version>7.0.0.Beta1-SNAPSHOT</version>
   </parent>
 
   <artifactId>docs</artifactId>

--- a/feature-spec-gen/pom.xml
+++ b/feature-spec-gen/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.wildfly.galleon-plugins</groupId>
     <artifactId>wildfly-provisioning-parent</artifactId>
-    <version>6.5.4.Final-SNAPSHOT</version>
+    <version>7.0.0.Beta1-SNAPSHOT</version>
   </parent>
 
   <artifactId>wildfly-feature-spec-gen</artifactId>

--- a/galleon-plugins/pom.xml
+++ b/galleon-plugins/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.wildfly.galleon-plugins</groupId>
     <artifactId>wildfly-provisioning-parent</artifactId>
-    <version>6.5.4.Final-SNAPSHOT</version>
+    <version>7.0.0.Beta1-SNAPSHOT</version>
   </parent>
 
   <artifactId>wildfly-galleon-plugins</artifactId>

--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.wildfly.galleon-plugins</groupId>
     <artifactId>wildfly-provisioning-parent</artifactId>
-    <version>6.5.4.Final-SNAPSHOT</version>
+    <version>7.0.0.Beta1-SNAPSHOT</version>
   </parent>
 
   <artifactId>wildfly-galleon-maven-plugin</artifactId>
@@ -114,6 +114,10 @@
     <dependency>
       <groupId>org.jboss.galleon</groupId>
       <artifactId>galleon-maven-universe</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.galleon</groupId>
+      <artifactId>galleon-core</artifactId>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/maven-plugin/src/main/java/org/wildfly/galleon/maven/AbstractFeaturePackBuildMojo.java
+++ b/maven-plugin/src/main/java/org/wildfly/galleon/maven/AbstractFeaturePackBuildMojo.java
@@ -381,6 +381,12 @@ public abstract class AbstractFeaturePackBuildMojo extends AbstractMojo {
                                 if (Files.exists(target)) {
                                     IoUtils.recursiveDelete(target);
                                 }
+                                try {
+                                    //Validate that we can parse this feature-pack...
+                                    FeaturePackDescriber.describeFeaturePack(versionDir,"UTF-8");
+                                } catch (ProvisioningDescriptionException ex) {
+                                    throw new RuntimeException(ex);
+                                }
                                 ZipUtils.zip(versionDir, target);
                                 debug("Attaching feature-pack %s as a project artifact", target);
                                 projectHelper.attachArtifact(project, "zip", target.toFile());

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 
   <groupId>org.wildfly.galleon-plugins</groupId>
   <artifactId>wildfly-provisioning-parent</artifactId>
-  <version>6.5.4.Final-SNAPSHOT</version>
+  <version>7.0.0.Beta1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>WildFly Galleon Plugins Parent</name>
@@ -76,7 +76,7 @@
     <version.org.codehaus.mojo.xml-maven-plugin>1.0.1</version.org.codehaus.mojo.xml-maven-plugin>
     <version.org.codehaus.plexus.plexus-utils>3.1.0</version.org.codehaus.plexus.plexus-utils>
     <version.org.eclipse.aether>1.1.0</version.org.eclipse.aether>
-    <version.org.jboss.galleon>5.2.2.Final</version.org.jboss.galleon>
+    <version.org.jboss.galleon>6.0.0.Beta1</version.org.jboss.galleon>
     <version.org.jboss.dmr>1.5.0.Final</version.org.jboss.dmr>
     
     <version.org.wildfly.channel>1.0.5.Final</version.org.wildfly.channel>

--- a/transformer/pom.xml
+++ b/transformer/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.wildfly.galleon-plugins</groupId>
     <artifactId>wildfly-provisioning-parent</artifactId>
-    <version>6.5.4.Final-SNAPSHOT</version>
+    <version>7.0.0.Beta1-SNAPSHOT</version>
   </parent>
 
   <artifactId>transformer</artifactId>


### PR DESCRIPTION
WildFly tests are expected to fail, would require a bump of provisioning tooling.