### PR TITLE
[WFGP-264] Start WF processes at a configurable stability level when …

### DIFF
--- a/maven-plugin/src/main/java/org/wildfly/galleon/maven/WfFeaturePackBuildMojo.java
+++ b/maven-plugin/src/main/java/org/wildfly/galleon/maven/WfFeaturePackBuildMojo.java
@@ -140,6 +140,14 @@ public class WfFeaturePackBuildMojo extends AbstractFeaturePackBuildMojo {
     @Parameter(alias = "feature-specs-output", defaultValue = "${project.build.directory}/resources/features", required = true)
     protected File featureSpecsOutput;
 
+    /**
+     * The minimum stability level of the WildFly processes used to generate feature specs.
+     * Set this if you need to generate feature specs for features with a lower stability level
+     * than the default level of the WildFly process being used for feature-spec generation.
+     */
+    @Parameter(alias = "minimum-stability", required = false)
+    protected String minimumStability;
+
     private WildFlyFeaturePackBuild buildConfig;
     private Map<String, PackageSpec.Builder> extendedPackages = Collections.emptyMap();
 


### PR DESCRIPTION
…generating feature specs

https://issues.redhat.com/browse/WFGP-264

This is a draft for discussion.

This uses a mojo @Parameter as the configuration mechanism, which I did largely to kick something out quickly so I could progress on working through issues with provisioning and stability levels. Perhaps the wildfly-feature-pack-build.xml file is a more logical place to place this configuration.