### PR TITLE
[WFGP-276] Check if the artifact is a ZIP or a JAR archive before extracting schemas

### DIFF
--- a/galleon-plugins/src/main/java/org/wildfly/galleon/plugin/WfInstallPlugin.java
+++ b/galleon-plugins/src/main/java/org/wildfly/galleon/plugin/WfInstallPlugin.java
@@ -1084,7 +1084,9 @@ public class WfInstallPlugin extends ProvisioningPluginWithOptions implements In
                 }
                 IoUtils.copy(jarSrc, jarTarget);
             }
-            if(schemaGroups.contains(artifact.getGroupId())) {
+            // only attempt to extract schemas if the artifact is a zip archive
+            if(schemaGroups.contains(artifact.getGroupId())
+                    && (artifact.getExtension().equals("jar") || artifact.getExtension().equals("zip"))) {
                 extractSchemas(jarSrc);
             }
         } catch (IOException e) {


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFGP-276
Upstream: #286
