### PR TITLE
[WFGP-298] Add copyright information when the feature pack is built

### DIFF
--- a/doc-gen/src/main/java/org/wildfly/galleon/plugin/doc/generator/Metadata.java
+++ b/doc-gen/src/main/java/org/wildfly/galleon/plugin/doc/generator/Metadata.java
@@ -27,6 +27,7 @@ public record Metadata(
         List<String> licenses,
         String url,
         @JsonProperty("scm-url") String scmUrl,
+        String copyright,
         List<Layer> layers) {
 
     static Metadata parse(Path file) throws IOException {
@@ -55,6 +56,7 @@ public record Metadata(
             metadata.licenses(),
             metadata.url(),
             metadata.scmUrl(),
+            metadata.copyright(),
             sortedLayers
         );
     }

--- a/doc-gen/src/main/resources/templates/index.html
+++ b/doc-gen/src/main/resources/templates/index.html
@@ -155,6 +155,12 @@
     {/for}
   </ul>
   {/if}
+  <footer>
+    {#if metadata.copyright}
+    <p>&copy; {metadata.copyright} {year}</p>
+    {/if}
+  </footer>
+</footer>
 </div>
 </body>
 </html>

--- a/doc-gen/src/main/resources/templates/log-message-reference.html
+++ b/doc-gen/src/main/resources/templates/log-message-reference.html
@@ -33,6 +33,11 @@
     </tbody>
   </table>
   {/for}
+  <footer>
+    {#if copyright}
+    <p>&copy; {copyright} {year}</p>
+    {/if}
+  </footer>
 </div>
 </body>
 </html>

--- a/doc-gen/src/main/resources/templates/resource.html
+++ b/doc-gen/src/main/resources/templates/resource.html
@@ -28,6 +28,11 @@
   {#include attributes attributes=resource.attributes /}
   {#include operations operations=resource.operations /}
   {#include features features=resource.features /}
+  <footer>
+    {#if copyright}
+    <p>&copy; {copyright} {year}</p>
+    {/if}
+  </footer>
 </div>
 </body>
 </html>

--- a/maven-plugin/src/main/java/org/wildfly/galleon/maven/AbstractFeaturePackBuildMojo.java
+++ b/maven-plugin/src/main/java/org/wildfly/galleon/maven/AbstractFeaturePackBuildMojo.java
@@ -267,6 +267,9 @@ public abstract class AbstractFeaturePackBuildMojo extends AbstractMojo {
     @Parameter(alias = "generate-complete-model", defaultValue = "false", required = true)
     protected Boolean generateCompleteModel;
 
+    @Parameter(alias = "copyright", property = "wildfly.feature.pack.copyright")
+    protected String copyright;
+
     private MavenProjectArtifactVersions artifactVersions;
 
     private Map<String, FeaturePackDescription> fpDependencies = Collections.emptyMap();
@@ -532,7 +535,7 @@ public abstract class AbstractFeaturePackBuildMojo extends AbstractMojo {
                                     ZipUtils.zip(versionDir, target);
 
                                     final Path metadata = Paths.get(project.getBuild().getDirectory()).resolve("metadata.json");
-                                    MetadataGenerator generator = new MetadataGenerator(project, repoSystem, repoSession, repositories, generateCompleteModel);
+                                    MetadataGenerator generator = new MetadataGenerator(project, repoSystem, repoSession, repositories, generateCompleteModel, copyright);
                                     generator.generateMetadata(target, desc, metadata);
                                 } catch (Exception ex) {
                                     throw new RuntimeException(ex);

--- a/maven-plugin/src/main/java/org/wildfly/galleon/maven/MetadataGenerator.java
+++ b/maven-plugin/src/main/java/org/wildfly/galleon/maven/MetadataGenerator.java
@@ -196,17 +196,21 @@ class MetadataGenerator {
     private final List<RemoteRepository> repositories;
     private final MavenProject project;
     private final boolean addFeaturePacksDependenciesInMetadata;
+    private final String copyright;
 
     MetadataGenerator(MavenProject project,
             RepositorySystem repoSystem,
             RepositorySystemSession repoSession,
             List<RemoteRepository> repositories,
-            boolean addFeaturePacksDependenciesInMetadata) {
+            boolean addFeaturePacksDependenciesInMetadata,
+            String copyright
+    ) {
         this.project = project;
         this.repoSystem = repoSystem;
         this.repoSession = repoSession;
         this.repositories = repositories;
         this.addFeaturePacksDependenciesInMetadata = addFeaturePacksDependenciesInMetadata;
+        this.copyright = copyright;
     }
 
     void generateMetadata(Path featurePack, FeaturePackDescription desc, Path metadataTarget) throws Exception {
@@ -302,7 +306,7 @@ class MetadataGenerator {
             }
         }
         Metadata metadata = new Metadata(project.getGroupId(), project.getArtifactId(), project.getVersion(), project.getName(), project.getDescription(), licenses,
-                project.getUrl(), scmUrl, layers);
+                project.getUrl(), scmUrl, copyright, layers);
         mapper.writerWithDefaultPrettyPrinter().writeValue(metadataTarget.toFile(), metadata);
     }
 


### PR DESCRIPTION
The copyright is used by the document generator to add a copyright footer to every
generated page.
This attribute is optional (and the copyright footer is not displayed if it is not set).
The year of the copyright is computed when the documentation is generated.

This fixes https://issues.redhat.com/browse/WFGP-298