### PR TITLE
fix: remove double zipping of the feature pack

### DIFF
--- a/maven-plugin/src/main/java/org/wildfly/galleon/maven/AbstractFeaturePackBuildMojo.java
+++ b/maven-plugin/src/main/java/org/wildfly/galleon/maven/AbstractFeaturePackBuildMojo.java
@@ -537,7 +537,6 @@ public abstract class AbstractFeaturePackBuildMojo extends AbstractMojo {
                                 } catch (Exception ex) {
                                     throw new RuntimeException(ex);
                                 }
-                                ZipUtils.zip(versionDir, target);
                                 if (project.getPackaging().equals(getPackaging())) {
                                     if (project.getArtifact().getFile() != null) {
                                         throw new MojoExecutionException("Cannot set " + target.getFileName()


### PR DESCRIPTION
Zipping twice the feature pack causes issues on Windows and throws
a java.nio.file.FileAlreadyExistsException

The actual zip occurs in the try/catch{} block to be available for the MetadataGenerator.