### PR TITLE
Update the copyright footer

### DIFF
--- a/doc-gen/src/main/java/org/wildfly/galleon/plugin/doc/generator/DocGenerator.java
+++ b/doc-gen/src/main/java/org/wildfly/galleon/plugin/doc/generator/DocGenerator.java
@@ -6,6 +6,7 @@
 package org.wildfly.galleon.plugin.doc.generator;
 
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
+import static org.wildfly.galleon.plugin.doc.generator.FeatureUtils.featureToURL;
 import static org.wildfly.galleon.plugin.doc.generator.LogMessageGenerator.exportLogMessages;
 import static org.wildfly.galleon.plugin.doc.generator.SimpleLog.SYSTEM_LOG;
 import static org.wildfly.galleon.plugin.doc.generator.TemplateUtils.ENGINE;
@@ -14,23 +15,19 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.time.Year;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.TreeMap;
 import java.util.stream.Stream;
 
 import io.quarkus.qute.Template;
-import java.util.Map;
-import java.util.TreeMap;
 import org.jboss.dmr.ModelNode;
-import static org.wildfly.galleon.plugin.doc.generator.FeatureUtils.featureToURL;
 
 public class DocGenerator {
-
-    private static final int YEAR = Year.now().getValue();
 
     /**
      * Generate the model reference in the {@code outputDirectory}
@@ -176,7 +173,6 @@ public class DocGenerator {
         String content = ENGINE.getTemplate("log-message-reference")
                 .data("codes", map)
                 .data("copyright", copyright)
-                .data("year", YEAR)
                 .render();
         FileUtils.writeToFile(outputDirectory.resolve("log-message-reference.html"), content);
         log.info("✏️ Log Message Reference page generated");
@@ -186,9 +182,9 @@ public class DocGenerator {
     private static void generateIndex(Path outputDirectory, Template index, Metadata metadata, boolean hasManagementAPI, boolean hasLogMessages) throws IOException {
         String content = index
                 .data("metadata", metadata)
+                .data("copyright", metadata.copyright())
                 .data("hasManagementAPI", hasManagementAPI)
                 .data("hasLogMessages", hasLogMessages)
-                .data("year", YEAR)
                 .render();
         FileUtils.writeToFile(outputDirectory.resolve("index.html"), content);
     }
@@ -208,7 +204,6 @@ public class DocGenerator {
                 .data("currentUrl", currentUrl)
                 .data("resource", resource)
                 .data("copyright", copyright)
-                .data("year", YEAR)
                 .data("breadcrumbs", Breadcrumb.build(path))
                 .data("relativePathToContextRoot", relativePathToContextRoot)
                 .render();

--- a/doc-gen/src/main/resources/styles.css
+++ b/doc-gen/src/main/resources/styles.css
@@ -553,3 +553,9 @@ h4:hover .anchor-link {
 .tab-content.active {
     display: block;
 }
+
+footer {
+  text-align: center;
+  font-size: 0.875rem;
+  color: #555;
+}

--- a/doc-gen/src/main/resources/templates/footer.html
+++ b/doc-gen/src/main/resources/templates/footer.html
@@ -1,0 +1,6 @@
+<footer>
+  <hr />
+  {#if copyright}
+  <p>{copyright}</p>
+  {/if}
+</footer>

--- a/doc-gen/src/main/resources/templates/index.html
+++ b/doc-gen/src/main/resources/templates/index.html
@@ -155,12 +155,7 @@
     {/for}
   </ul>
   {/if}
-  <footer>
-    {#if metadata.copyright}
-    <p>&copy; {metadata.copyright} {year}</p>
-    {/if}
-  </footer>
-</footer>
+  {#include footer /}
 </div>
 </body>
 </html>

--- a/doc-gen/src/main/resources/templates/log-message-reference.html
+++ b/doc-gen/src/main/resources/templates/log-message-reference.html
@@ -33,11 +33,7 @@
     </tbody>
   </table>
   {/for}
-  <footer>
-    {#if copyright}
-    <p>&copy; {copyright} {year}</p>
-    {/if}
-  </footer>
+  {#include footer /}
 </div>
 </body>
 </html>

--- a/doc-gen/src/main/resources/templates/resource.html
+++ b/doc-gen/src/main/resources/templates/resource.html
@@ -28,11 +28,8 @@
   {#include attributes attributes=resource.attributes /}
   {#include operations operations=resource.operations /}
   {#include features features=resource.features /}
-  <footer>
-    {#if copyright}
-    <p>&copy; {copyright} {year}</p>
-    {/if}
-  </footer>
+
+  {#include footer /}
 </div>
 </body>
 </html>


### PR DESCRIPTION
Depending on the author of the feature pack, the copyright can be substantially different.
The feature pack developer must now provide a complete copyright HTML snippet that is added to the footer of the generated pages. If the copyright parameter is not present, no copyright will be displayed.