### PR TITLE
Fix for WFGP-302, Wildfly Galleon Maven plugins contains a useless dependency on config-gen

### DIFF
--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -121,10 +121,6 @@
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>wildfly-config-gen</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
       <artifactId>wildfly-feature-spec-gen</artifactId>
     </dependency>
     <dependency>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFGP-302