### PR TITLE
Fix for WFGP-306, Example configs are not generated in the order of FP declared in config

### DIFF
--- a/galleon-plugins/src/main/java/org/wildfly/galleon/plugin/WfInstallPlugin.java
+++ b/galleon-plugins/src/main/java/org/wildfly/galleon/plugin/WfInstallPlugin.java
@@ -173,7 +173,7 @@ public class WfInstallPlugin extends ProvisioningPluginWithOptions implements In
     private TransformerFactory xsltFactory;
     private Map<String, Transformer> xslTransformers = Collections.emptyMap();
 
-    private Map<FPID, ExampleFpConfigs> exampleConfigs = Collections.emptyMap();
+    private Map<FPID, ExampleFpConfigs> exampleConfigs = new LinkedHashMap<>();
 
     private ProgressTracker<PackageRuntime> pkgProgressTracker;
 
@@ -1096,7 +1096,7 @@ public class WfInstallPlugin extends ProvisioningPluginWithOptions implements In
         }
         ExampleFpConfigs existingConfigs = this.exampleConfigs.get(originFpId);
         if(existingConfigs == null) {
-            this.exampleConfigs = CollectionUtils.put(this.exampleConfigs, originFpId, exampleConfigs);
+            this.exampleConfigs = CollectionUtils.putLinked(this.exampleConfigs, originFpId, exampleConfigs);
         } else {
             existingConfigs.addAll(exampleConfigs);
         }


### PR DESCRIPTION
ISSUE: https://issues.redhat.com/browse/WFGP-306