### PR TITLE
Append .exe to java executable path on Windows

### DIFF
--- a/galleon-plugins/src/main/java/org/wildfly/galleon/plugin/server/ForkedEmbeddedUtil.java
+++ b/galleon-plugins/src/main/java/org/wildfly/galleon/plugin/server/ForkedEmbeddedUtil.java
@@ -74,8 +74,13 @@ public class ForkedEmbeddedUtil {
         return javaHome == null ? javaHome = System.getProperty("java.home") : javaHome;
     }
 
+    private static final boolean IS_WINDOWS = System.getProperty("os.name", "").toLowerCase(java.util.Locale.ROOT).contains("win");
+
     private static String getJavaCmd() {
-        return javaCmd == null ? javaCmd = Paths.get(getJavaHome()).resolve("bin").resolve("java").toString() : javaCmd;
+        if (javaCmd == null) {
+            javaCmd = Paths.get(getJavaHome()).resolve("bin").resolve(IS_WINDOWS ? "java.exe" : "java").toString();
+        }
+        return javaCmd;
     }
 
     public static void fork(ForkCallback callback, boolean debug, String... args) throws ProvisioningException {


### PR DESCRIPTION
ForkedEmbeddedUtil constructs the forked JVM command as <java.home>/bin/java which fails on Windows with "CreateProcess error=193, %1 is not a valid Win32 application" because Windows requires the .exe extension.