### PR TITLE
fix: Add stability info for resources

### DIFF
--- a/doc-gen/src/main/java/org/wildfly/galleon/plugin/doc/generator/Resources.java
+++ b/doc-gen/src/main/java/org/wildfly/galleon/plugin/doc/generator/Resources.java
@@ -74,7 +74,7 @@ record Capability(String name, boolean dynamic, List<String> providerPoints) {
     }
 }
 
-record Resource(String description, String storage, Deprecation deprecation, List<Capability> capabilities, List<Child> children, List<Attribute> attributes, List<Operation> operations, Set<Feature> features) {
+record Resource(String description, String stability, String storage, Deprecation deprecation, List<Capability> capabilities, List<Child> children, List<Attribute> attributes, List<Operation> operations, Set<Feature> features) {
     public static Resource fromModelNode(PathAddress pathAddress, ModelNode node, ModelNode featureNode, Map<String, Capability> capabilities) {
         List<Child> children = emptyList();
         if (node.hasDefined("children")) {
@@ -108,8 +108,9 @@ record Resource(String description, String storage, Deprecation deprecation, Lis
         if (node.hasDefined("description")) {
             description = node.get("description").asString();
         }
+        String stability = node.get("stability").asStringOrNull();
         Set<Feature> features = Feature.fromModelNode(featureNode, children);
-        return new Resource(description, storage, Deprecation.fromModel(node), Capability.fromModelList(node.get("capabilities"), capabilities, pathAddress), children, attributes, operations, features == null ? emptySet() : features);
+        return new Resource(description, stability, storage, Deprecation.fromModel(node), Capability.fromModelList(node.get("capabilities"), capabilities, pathAddress), children, attributes, operations, features == null ? emptySet() : features);
     }
 }
 
@@ -124,7 +125,7 @@ record Feature(String name, String xmlContent) implements Comparable<Feature> {
     }
 }
 
-record Child(String name, String description, Deprecation deprecation,
+record Child(String name, String description, String stability, Deprecation deprecation,
              List<Child> children) implements Comparable<Child> {
     public static Child fromProperty(final Property property) {
         String name = property.getName();
@@ -135,13 +136,17 @@ record Child(String name, String description, Deprecation deprecation,
         if (modelDesc.isDefined()) {
             for (Property child : modelDesc.asPropertyList()) {
                 if (!child.getName().equals("*")) {
-                    registrations.add(new Child(child.getName(), child.getValue().get("description").asString(""), Deprecation.fromModel(child.getValue()), emptyList()));
+                    registrations.add(new Child(child.getName(), child.getValue().get("description").asString(""), child.getValue().get("stability").asStringOrNull(), Deprecation.fromModel(child.getValue()), emptyList()));
                 }
             }
         }
         sort(registrations);
 
-        return new Child(name, description, Deprecation.fromModel(property.getValue()), registrations);
+        String stability = property.getValue().get("stability").asStringOrNull();
+        if (stability == null && modelDesc.isDefined() && modelDesc.hasDefined("*")) {
+            stability = modelDesc.get("*").get("stability").asStringOrNull();
+        }
+        return new Child(name, description, stability, Deprecation.fromModel(property.getValue()), registrations);
     }
 
     @Override

--- a/doc-gen/src/main/resources/templates/attributes.html
+++ b/doc-gen/src/main/resources/templates/attributes.html
@@ -5,14 +5,7 @@
   <li>
     <span class="toggle-link">
       <a id="{attribute.name}" href="#{attribute.name}" class="{#if attribute.deprecation.deprecated}deprecated{/if}">
-        {#switch attribute.stability}
-        {#case "experimental"}
-         <abbr title="Experimental feature">&#x1F174;</abbr>&nbsp;
-         {#case "preview"}
-         <abbr title="Preview feature">&#x1F17F;</abbr>&nbsp;
-         {#case "community"}
-         <abbr title="Community feature">&#x1F172;</abbr>&nbsp;
-         {/switch}
+        {#include stability-badge stability=attribute.stability /}
          {attribute.name}</a> - {attribute.description}
     </span>
     <div class="collapsible">

--- a/doc-gen/src/main/resources/templates/children.html
+++ b/doc-gen/src/main/resources/templates/children.html
@@ -4,14 +4,18 @@
   {#for child in children}
   <li>
     {#if child.children.size == 0}
-    <a href="{child.name}/index.html" class="{#if child.deprecation.deprecated}deprecated{/if}">{child.name}</a>
+    <a href="{child.name}/index.html" class="{#if child.deprecation.deprecated}deprecated{/if}">
+      {#include stability-badge stability=child.stability /}
+      {child.name}</a>
     {#else}
     <b>{child.name}</b>
     {/if}
     {#if child.children.size > 0}
     <ul>
       {#for c in child.children}
-      <li><a href="{child.name}/{c.name}/index.html" class="{#if c.deprecation.deprecated}deprecated{/if}">{c.name}</a></li>
+      <li><a href="{child.name}/{c.name}/index.html" class="{#if c.deprecation.deprecated}deprecated{/if}">
+        {#include stability-badge stability=c.stability /}
+        {c.name}</a></li>
       {/for}
     </ul>
     {/if}

--- a/doc-gen/src/main/resources/templates/operations.html
+++ b/doc-gen/src/main/resources/templates/operations.html
@@ -5,14 +5,7 @@
   <li>
     <span class="toggle-link">
       <a id="{operation.name}" href="#{operation.name}" class="{#if operation.deprecation.deprecated}deprecated{/if}">
-      {#switch operation.stability}
-      {#case "experimental"}
-      <abbr title="Experimental feature">&#x1F174;</abbr>&nbsp;
-      {#case "preview"}
-      <abbr title="Preview feature">&#x1F17F;</abbr>&nbsp;
-      {#case "community"}
-      <abbr title="Community feature">&#x1F172;</abbr>&nbsp;
-      {/switch}
+      {#include stability-badge stability=operation.stability /}
       {operation.name}</a> - {operation.description}
     </span>
     <div class="collapsible">

--- a/doc-gen/src/main/resources/templates/resource.html
+++ b/doc-gen/src/main/resources/templates/resource.html
@@ -16,6 +16,12 @@
     <h1>Management API Reference for {breadcrumbs.last.label}</h1>
     <p>{resource.description}</p>
 
+    {#if resource.stability}
+    <div>
+      <strong>Stability Level:</strong> {resource.stability}
+    </div>
+    {/if}
+
     {#if resource.deprecation.deprecated}
     <div class="alert">
       <strong>Deprecated</strong> Since {resource.deprecation.since}

--- a/doc-gen/src/main/resources/templates/stability-badge.html
+++ b/doc-gen/src/main/resources/templates/stability-badge.html
@@ -1,0 +1,8 @@
+{#switch stability}
+{#case "experimental"}
+<abbr title="Experimental feature">&#x1F174;</abbr>&nbsp;
+{#case "preview"}
+<abbr title="Preview feature">&#x1F17F;</abbr>&nbsp;
+{#case "community"}
+<abbr title="Community feature">&#x1F172;</abbr>&nbsp;
+{/switch}


### PR DESCRIPTION
In the generated documentation, add the stability level to the resource header (if it is defined).
Add a stability badge to their children resources. Refactor the template to reuse a stability-badge template.

This fixes #363