### PR TITLE
Fix for WFGP-317, Improper null handling for MetadataGenerator.getFeatureGroup

### DIFF
--- a/maven-plugin/src/main/java/org/wildfly/galleon/maven/MetadataGenerator.java
+++ b/maven-plugin/src/main/java/org/wildfly/galleon/maven/MetadataGenerator.java
@@ -592,7 +592,7 @@ class MetadataGenerator {
                 return layout.loadFeatureGroupSpec(name);
             }
         }
-        return null;
+        throw new ProvisioningException("feature-group " + name + " not found in the provisioning config.");
     }
 
     private static void generateModelUpdates(List<ConfigItem> items,


### PR DESCRIPTION
ISSUE: https://redhat.atlassian.net/browse/WFGP-317
